### PR TITLE
Info and Errors (and other bug fixes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,172 +1,183 @@
 ***
-Aauth is a User Authorization Library for CodeIgniter 2.x, which aims to make easy some essential jobs such as login, permissions and access operations. Despite ease of use, it has also very advanced features like private messages, groupping, access management, public access etc..
+Aauth is a User Authorization Library for CodeIgniter 2.x, which aims to make easy some essential jobs such as login, permissions and access operations. Despite its ease of use, it has also very advanced features like private messages, groupping, access management, and public access.
 
-**This is Quick Start page. After Quick Start, Take a look [detailed Documentation from wiki](https://github.com/emreakay/CodeIgniter-Aauth/wiki/_pages) to learn other great Features**
+**This is Quick Start page. You can also take a look at the [detailed Documentation Wiki](https://github.com/emreakay/CodeIgniter-Aauth/wiki/_pages) to learn about other great Features**
 
 ### Features 
 ***
-* User Management and Operations (login, logout, register, vertification via e-mail, forgoten password, ban management, login ddos protection)
-* Group Operations (Creaing, deleting groups, membership management)
+* User Management and Operations (login, logout, register, verification via e-mail, forgotten password, user ban, login DDoS protection)
+* Group Operations (creating/deleting groups, membership management)
 * Admin and Public Group support (Public permissions)
-Permission Management (creating,deleting permissons, allow, deny groups, public permissions, permission checking)
-* Group Permissions 
-* User Permissions (new)
-* User and System Variables (new)
-* Login Ddos Protection (new)
-* Private Messages (pm between users)
-* Error Mesages and Validations
+* Permission Management (creating/deleting permissions, allow/deny groups, public permissions, permission checking)
+* Group Permissions
+* User Permissions
+* User and System Variables
+* Login DDoS Protection
+* Private Messages (between users)
+* Error Messages and Validations
 * Langugage and config file support
-* Flexible
+* Flexible implementation
 
 ### What is new in Version 2
 ***
 * User Permissions
 * User and System Variables
-* Login Ddos Protection
-* Some functions has changed
-* Some bugs fixed
+* Login DDoS Protection
+* Updated functions (check documentation for details)
+* Bugs fixes
 
 ### Migration
 ***
-* if you have been using Version 1 before, take a look at [migration page from here.](https://github.com/emreakay/CodeIgniter-Aauth/wiki/1%29-Migration-from-V1).
+* If you are currently using Version 1, take a look at the [v1 to v2 migration page.](https://github.com/emreakay/CodeIgniter-Aauth/wiki/1%29-Migration-from-V1).
 
 ### Quick Start 
 ***
-Let's start :)  
-Firstly we will load Aauth Library to system
+Let's get started :)
+First, we will load the Aauth Library into the system
 ```php
 $this->load->library("Aauth");
 ```
-  
-thats OK.  
 
-Now we will create 2 new users, Ali and John  
+That was easy!
+
+Now let's create two new users, `Frodo` and `Legolas`.
 
 ```php
-$this->aauth->create_user('ali@ali.com','alispass','Ali Akay');
-$this->aauth->create_user('john@john.com','johnspass','John Button');
+$this->aauth->create_user('frodo@example.com','frodopass','Frodo Baggins');
+$this->aauth->create_user('legolas@example.com','legolaspass','Legolas');
 ```
    
-thats it. now we have two users.
+We now we have two users.
 
-Lets Create two group governors and commons :)
+OK, now we can create two groups, `hobbits` and `elves`.
 ```php
-$this->aauth->create_group('governors');
-$this->aauth->create_group('commons');
+$this->aauth->create_group('hobbits');
+$this->aauth->create_group('elves');
 ```  
 
-Then, Lets Create a User with power whic is Obama (having id=12)
+Now, let's create a user with power, Gandalf (for our example, let's assume he was given the `id` of 12).
 ```php
-$this->aauth->create_user('obama@usa.gov', 'pass-cia-fbi', 'Barrack Obama');
+$this->aauth->create_user('gandalf@example.com', 'gandalfpass', 'Gandalf the Gray');
 ```  
 
-ok now we have two groups and one user.
+OK, now we have two groups and three users.
 
-Lets create a permissions 'incrase_tax' and 'change_government' 
+Let's create two permissions `walk_unseen` and `immortality` 
 
 ```php
-$this->aauth->create_perm('increase_tax');
-$this->aauth->create_perm('change_government');
+$this->aauth->create_perm('walk_unseen');
+$this->aauth->create_perm('immortality');
 ```  
 
-Ok, now lets give accesses. logically 'governors' will have 'increase_tax' permission and 'commons' will have 'change_government' access.  
-ok lets give proper access with _alow_group()_ function
+Ok, now let's give accesses to our groups.  The Hobbits seem to have ability to walk unseen, so we will assign that privilage to them. The Elves have imortality, so we will assign that privilage to them.
+We will assign access with `allow_group()` function.
 
 ```php
-$this->aauth->allow_group('governors','increase_tax');
-$this->aauth->allow_group('commons','change_government');
+$this->aauth->allow_group('hobbits','walk_unseen');
+$this->aauth->allow_group('elves','immortality');
   
   
-$this->aauth->allow_group('commons','increase_tax');
+$this->aauth->allow_group('hobbits','immortality');
 ``` 
 
-Ops wait a minute.  commons cannot 'increase_tax'. we need to fix it, we will use deny() to take back permission.
+Wait a minute! Hobbits should not have `immortality`. We need to fix this, we can use `deny()` to remove the permission.
 
 ```php
-$this->aauth->deny('commons','increase_tax');
+$this->aauth->deny('hobbits','immortality');
 ``` 
 
-Obama also can increse tax ha?
+Gandalf can also live forever.
 
 ```php
-$this->aauth->allow_user(12,'increase_tax');
+$this->aauth->allow_user(12,'immortality');
 ``` 
 
-
-Ok now lets check if commons can 'increase_tax'
+Ok now let's check if Hobbits have `immortality`.
 
 ```php
-if($this->aauth->is_group_allowed('commons','increase_tax')){
-    // i dont think so
+if($this->aauth->is_group_allowed('hobbits','immortality')){
+	echo "Hobbits are immortal";
 } else {
-   // do sth in the middle
+	echo "Hobbits are NOT immortal";
+}
+```
+Results:
+```
+Hobbits are NOT immortal
+```
+
+Does Gandalf have the ability to live forever?
+
+```php
+if($this->aauth->is_allowed(12,'immortality')){
+	echo "Gandalf is immortal";
+} else {
+	echo "Gandalf is NOT immortal";
 }
 ``` 
+Results:
+```
+Gandalf is immortal
+```
 
-Can Obama increase_tax ? Let's check it.
-
-```php
-if($this->aauth->is_allowed(15,'increase_tax')){
-    // i guess so
-} else {
-   // piece of code
-}
-``` 
-
-
-i think 'increse_tax' must have never been created. just delete it
+Since we don't accually live in Middle Earth, we are not aware of actual immortality.  Alas, we must delete the permission.
 
 ```php
-$this->aauth->delete_perm('increase_tax');
+$this->aauth->delete_perm('immortality');
 ``` 
-now better.  
-  
-So what about public people? (public means not logged users). Can public people travel? Lets assume we have permissions namely 'travel' , of course.
+It is gone.
+
+#### Un-authenticated Users
+
+So, how about un-authenticated users?  In Aauth they are part of the `public` group. Let's give them permissions to `travel`.
+We will assume we already have a permission set up named `travel`.
 
 ```php
 $this->aauth->allow_group('public','travel');
 ``` 
-  
-So Admin? what can he do? He can access everthing, You dont need to give permiision ( using allow_group() or allow_user() ) him, he already has.  
-  
-What about User Variables?
-for every individual user, variables can be defined as key-value.
 
-this is a simple example to set a variable.
+#### Admin Users
+What about the Admin users? The `Admin` user and any member of the `Admin` group is a superuser who had access everthing, There is no need to grant additional permissions.
+  
+#### User Parameters/Variables
+For each user, variables can be defined as individual key/value pairs.
+
 ```php
 $this->aauth->set_user_var("key","value");
 ``` 
 
-For example if you want to keep users phones
+For example, if you want to store a user's phone number.
 ```php
-$this->aauth->set_user_var("phone","0216 313 23 33");
+$this->aauth->set_user_var("phone","1-507-555-1234");
 ``` 
 
-to get the variable
+To retreive value you will use `get_user_var()`:
 ```php
 $this->aauth->get_user_var("key");
 ``` 
 
-Aauth also permits you to define System Variables which can be accesed by every user in the system.
+Aauth also permits you to define System Variables.  These can be which can be accesed by all users in the system.
 ```php
-$this->aauth->set_system_var("key","Value");
+$this->aauth->set_system_var("key","value");
 $this->aauth->get_system_var("key");
 ``` 
 
-ok lets look at private messages. John (his id=3) will send pm to Ali(id=4)
+#### Private Messages
+OK, let's look at private messages. Frodo (`id` = 3) will send a PM to Legolas (`id` = 4);
 
 ```php
-$this->aauth->send_pm(3,4,'Hi bro. i need you',' can you gimme your credit card?')
+$this->aauth->send_pm(3,4,'New cloaks','These new cloaks are fantastic!')
 ``` 
-  
-sorry John you will be banned :(
 
+#### Banning users
+
+Frodo has broke the rules and will not need to be banned from the system.
 ```php
 $this->aauth->ban_user(3);
 ``` 
- 
-Quick Start is done but thats not the end  
-Take a look [detailed Documentation from wiki](https://github.com/emreakay/CodeIgniter-Aauth/wiki/_pages)   
 
-Dont forget to watch Aauth.  
-You can also contribute and help me :)
+You have reached the end of the Quick Start Guide, but please take a look at the [detailed Documentation Wiki](https://github.com/emreakay/CodeIgniter-Aauth/wiki/_pages) for additional information.
+
+
+Don't forget to keep and eye on Aauth, we are constantly improving the system.
+You can also contribute and help me out. :)

--- a/application/config/aauth.php
+++ b/application/config/aauth.php
@@ -1,7 +1,4 @@
-<?php
-
-if (!defined('BASEPATH'))
-    exit('No direct script access allowed');
+<?php if (!defined('BASEPATH')) exit('No direct script access allowed');
 /*
   | -------------------------------------------------------------------
   |  Aauth Config
@@ -74,5 +71,5 @@ $config['aauth'] = array(
 );
 
 
-/* End of file autoload.php */
-/* Location: ./application/config/autoload.php */
+/* End of file aauth.php */
+/* Location: ./application/config/aauth.php */

--- a/application/language/english/aauth_lang.php
+++ b/application/language/english/aauth_lang.php
@@ -1,35 +1,47 @@
 <?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
 
-$lang['verification_subject'] = 'Account Vertification';
-$lang['reset'] = 'Pasword Reset';
+/* E-mail Messages */
 
-// error mesages
-// change to your language
+// Account verification
+$lang['aauth_email_verification_subject'] = 'Account Verification';
+$lang['aauth_email_verification_code'] = 'Your verification code is: ';
+$lang['aauth_email_verification_link'] = " You can also click on (or copy and paste) the following link\n\nhttp://yourdomain/account/verification/";
 
-$lang['email_taken'] = 'E-mail is already taken';
-$lang['email_invalid'] = 'E-mail invalid';
-$lang['pass_invalid'] = 'Password invalid';
-$lang['name_invalid'] = 'Name invalid';
-$lang['code'] = 'Your code is: ';
-$lang['link'] = ' or you can copy and paste falowing link http://localhost/vert/';
+// Password reset
+$lang['aauth_email_reset_subject'] = 'Reset Password';
+$lang['aauth_email_reset_link'] = "To reset your password click on (or copy and paste in your browser address bar) the link below:\n\nhttp://yourdomain/account/reset_password/";
 
-$lang['remind'] = 'If you want to reset your password click the copy and go the link below http://localhost/reset/';
-$lang['new_password'] = 'Your new password is : ';
+// Password reset success
+$lang['aauth_email_reset_success_subject'] = 'Successful Pasword Reset';
+$lang['aauth_email_reset_success_new_password'] = 'Your password has successfully been reset. Your new password is : ';
 
-// no access
-$lang['no_access'] = 'You dont have access.';
 
-//
-$lang['wrong'] = 'E-mail or Password is wrong.';
-$lang['exceeded'] = 'Login try limit exceeded.';
-$lang['recaptcha_not_correct'] = 'reCAPTCHA is incorrect.';
-$lang['no_user'] = 'User not Exist';
-$lang['not_verified'] = 'Please verify your account.';
-$lang['group_exist'] = 'Group already exists';
-$lang['no_group'] = 'Group doesn\'t exists';
-$lang['self_pm'] = 'It is not reasonable to send pm to yourself :)';
-$lang['no_pm'] = 'Pm not found';
+/* Error Messages */
 
-//info
-$lang['already_member'] = 'User already member of group';
-$lang['already_perm'] = 'Permission name already existed';
+// Account creation errors
+$lang['aauth_error_email_exists'] = 'Email address already exists on the system. If you forgot your password, you can click the link below.';
+$lang['aauth_error_username_exists'] = "Account already exists on the system with that username.  Please enter a different username, or if you forgot your password, please click the link below.";
+$lang['aauth_error_email_invalid'] = 'Invalid e-mail address';
+$lang['aauth_error_password_invalid'] = 'Invalid password';
+$lang['aauth_error_username_invalid'] = 'Invalid Username';
+$lang['aauth_error_username_required'] = 'Username required';
+
+// Access errors
+$lang['aauth_error_no_access'] = 'Sorry, you do not have access to the resource you requested.';
+$lang['aauth_error_login_failed'] = 'E-mail Address and Password do not match.';
+$lang['aauth_error_login_attempts_exceeded'] = 'You have exceeded your login attempts, your account has now been locked.';
+$lang['aauth_error_recaptcha_not_correct'] = 'Sorry, the reCAPTCHA text entered was incorrect.';
+
+
+// Misc. errors
+$lang['aauth_error_no_user'] = 'User does not exist';
+$lang['aauth_error_account_not_verified'] = 'Your account has not been verified. Please check your e-mail and verify your account.';
+$lang['aauth_error_no_group'] = 'Group does not exist';
+$lang['aauth_error_self_pm'] = 'It is not possible to send a Message to yourself.';
+$lang['aauth_error_no_pm'] = 'Private Message not found';
+
+
+/* Info messages */
+$lang['aauth_info_already_member'] = 'User is already member of group';
+$lang['aauth_info_group_exists'] = 'Group name already exists';
+$lang['aauth_info_perm_exists'] = 'Permission name already exists';

--- a/application/libraries/Aauth.php
+++ b/application/libraries/Aauth.php
@@ -21,30 +21,35 @@
  * https://github.com/emreakay/CodeIgniter-Aauth
  *
  * @todo separate (on some level) the unvalidated users from the "banned" users
- * @todo remove requirement for unique name/username (or default it to use email address, perhaps via config file)
+ * @todo remove requirement for unique name/username (or default it to use email address, perhaps via config file).  OR remove altogether as login uses email address
+ * @todo add configuration to not use cookies if sessions are enabled.
  */
 class Aauth {
 
     /**
      * The CodeIgniter object variable
+     * @access public
      * @var object
      */
     public $CI;
 
     /**
      * Variable for loading the config array into
+     * @access public
      * @var array
      */
     public $config_vars;
 
     /**
      * Array to store error messages
+     * @access public
      * @var array
      */
     public $errors = array();
 
     /**
      * Array to store info messages
+     * @access public
      * @var array
      */
     public $infos = array();
@@ -307,6 +312,7 @@ class Aauth {
      * error message, unless 'no_permission' value is set in config.  If 'no_permission' is
      * set in config it redirects user to the set url and passes the 'no_access' error message.
      * It also updates last activity every time function called.
+     *
      * @param bool $perm_par If not given just control user logged in or not
      */
     public function control( $perm_par = false ){
@@ -352,6 +358,7 @@ class Aauth {
      * Fast login
      * Login with just a user id
      * @param int $user_id User id to log in
+     * @return bool true if login successful.
      */
     public function login_fast($user_id){
 
@@ -373,7 +380,9 @@ class Aauth {
             );
 
             $this->CI->session->set_userdata($data);
+            return true;
         }
+        return false;
     }
 
     /**
@@ -754,6 +763,7 @@ class Aauth {
      * Send verification email
      * Sends a verification email based on user id
      * @param int $user_id User id to send verification email to
+     * @todo return success indicator
      */
     public function send_verification($user_id){
 
@@ -1650,9 +1660,9 @@ class Aauth {
      * Error
      * Add message to error array and set flash data
      * @param string $message Message to add to array
-     * @param boolean $flashdata if true add $message to CI flashdata (deflault: true)
+     * @param boolean $flashdata if true add $message to CI flashdata (deflault: false)
      */
-    public function error($message = '', $flashdata = true){
+    public function error($message = '', $flashdata = false){
         $this->errors[] = $message;
         if($flashdata) {
 			$this->CI->session->set_flashdata('errors', $this->errors);
@@ -1674,14 +1684,14 @@ class Aauth {
     /**
      * Get Errors Array
      * Return array of errors
-     * @return array|bool Array of messages or false if no errors
+     * @return array Array of messages, empty array if no errors
      */
     public function get_errors_array(){
 
         if (!count($this->errors)==0){
             return $this->errors;
         } else {
-            return false;
+            return array();
         }
     }
 
@@ -1724,9 +1734,9 @@ class Aauth {
      * Add message to info array and set flash data
      * 
      * @param string $message Message to add to infos array
-     * @param boolean $flashdata if true add $message to CI flashdata (deflault: true)
+     * @param boolean $flashdata if true add $message to CI flashdata (deflault: false)
      */
-    public function info($message = '', $flashdata = true){
+    public function info($message = '', $flashdata = false){
 
         $this->infos[] = $message;
         if($flashdata) {
@@ -1749,14 +1759,14 @@ class Aauth {
     /**
      * Get Info Array
      * Return array of info
-     * @return array|bool Array of messages or false if no errors
+     * @return array Array of messages, empty array if no errors
      */
     public function get_infos_array(){
 
         if (!count($this->infos)==0){
             return $this->infos;
         } else {
-            return false;
+            return array();
         }
     }
 

--- a/application/libraries/Aauth.php
+++ b/application/libraries/Aauth.php
@@ -20,8 +20,6 @@
  * The latest version of Aauth can be obtained from:
  * https://github.com/emreakay/CodeIgniter-Aauth
  *
- * @todo implement same fix for "info" as was implemented for "errors"
- *
  */
 class Aauth {
 
@@ -80,8 +78,9 @@ class Aauth {
         $this->CI->config->load('aauth');
         $this->config_vars = $this->CI->config->item('aauth');
         
-        // load error messages from flashdata (but don't store back in flashdata)
+        // load error and info messages from flashdata (but don't store back in flashdata)
         $this->errors = $this->CI->session->flashdata('errors');
+        $this->infos = $this->CI->session->flashdata('infos');
     }
 
 
@@ -1711,7 +1710,7 @@ class Aauth {
     /**
      * Clear Errors
      * 
-     * Removes errors from error list and clears all flashdata
+     * Removes errors from error list and clears all associated flashdata
      */
     public function clear_errors() {
     	$this->errors = [];
@@ -1721,16 +1720,22 @@ class Aauth {
     //tested
     /**
      * Info
+     *
      * Add message to info array and set flash data
-     * @param string $message Message to add to array
+     * 
+     * @param string $message Message to add to infos array
+     * @param boolean $flashdata if true add $message to CI flashdata (deflault: true)
      */
-    public function info($message){
+    public function info($message = '', $flashdata = true){
 
         $this->infos[] = $message;
-        $this->CI->session->set_flashdata('infos', $this->errors);
+        if($flashdata) {
+			$this->CI->session->set_flashdata('infos', $this->infos);
+		}
     }
 
     //not working
+    // NOTE: This should now be working
     /**
      * Keep Infos
      * keeps the flash data
@@ -1778,6 +1783,16 @@ class Aauth {
             $i++;
         }
         echo $msg;
+    }
+    
+    /**
+     * Clear Info List
+     * 
+     * Removes info messages from info list and clears all associated flashdata
+     */
+    public function clear_errors() {
+    	$this->infos = [];
+    	$this->CI->session->set_flashdata('infos', $this->infos);
     }
 
     ########################

--- a/application/libraries/Aauth.php
+++ b/application/libraries/Aauth.php
@@ -6,7 +6,7 @@
  * Despite ease of use, it has also very advanced features like private messages, 
  * groupping, access management, public access etc..
  *
- * @author      Emre Akay <emreakayfb@hotmail.com>
+ * @author		Emre Akay <emreakayfb@hotmail.com>
  * @contributor Jacob Tomlinson
  * @contributor Tim Swagger (Renowne, LLC) <tim@renowne.com>
  *
@@ -21,2031 +21,2033 @@
  * https://github.com/emreakay/CodeIgniter-Aauth
  *
  * @todo separate (on some level) the unvalidated users from the "banned" users
- * @todo remove requirement for unique name/username (or default it to use email address, perhaps via config file).  OR remove altogether as login uses email address
+ * @todo remove requirement for unique name/username (or default it to use email address, perhaps via config file).	 OR remove altogether as login uses email address
  * @todo add configuration to not use cookies if sessions are enabled.
  */
 class Aauth {
 
-    /**
-     * The CodeIgniter object variable
-     * @access public
-     * @var object
-     */
-    public $CI;
+	/**
+	 * The CodeIgniter object variable
+	 * @access public
+	 * @var object
+	 */
+	public $CI;
 
-    /**
-     * Variable for loading the config array into
-     * @access public
-     * @var array
-     */
-    public $config_vars;
+	/**
+	 * Variable for loading the config array into
+	 * @access public
+	 * @var array
+	 */
+	public $config_vars;
 
-    /**
-     * Array to store error messages
-     * @access public
-     * @var array
-     */
-    public $errors = array();
+	/**
+	 * Array to store error messages
+	 * @access public
+	 * @var array
+	 */
+	public $errors = array();
 
-    /**
-     * Array to store info messages
-     * @access public
-     * @var array
-     */
-    public $infos = array();
+	/**
+	 * Array to store info messages
+	 * @access public
+	 * @var array
+	 */
+	public $infos = array();
 
-    ########################
-    # Base Functions
-    ########################
+	########################
+	# Base Functions
+	########################
 
-    /**
-     * Constructor
-     */
-    public function __construct() {
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
 
-        // get main CI object
-        $this->CI = & get_instance();
+		// get main CI object
+		$this->CI = & get_instance();
 
-        // Dependancies
-        if(CI_VERSION >= 2.2){
-            $this->CI->load->library('driver');
-        }
-        $this->CI->load->library('session');
-        $this->CI->load->library('email');
-        $this->CI->load->database();
-        $this->CI->load->helper('url');
-        $this->CI->load->helper('string');
-        $this->CI->load->helper('email');
-        $this->CI->load->helper('language');
-        $this->CI->load->helper('recaptchalib');
-        $this->CI->lang->load('aauth');
-
-
-        // config/aauth.php
-        $this->CI->config->load('aauth');
-        $this->config_vars = $this->CI->config->item('aauth');
-        
-        // load error and info messages from flashdata (but don't store back in flashdata)
-        $this->errors = $this->CI->session->flashdata('errors');
-        $this->infos = $this->CI->session->flashdata('infos');
-    }
+		// Dependancies
+		if(CI_VERSION >= 2.2){
+			$this->CI->load->library('driver');
+		}
+		$this->CI->load->library('session');
+		$this->CI->load->library('email');
+		$this->CI->load->database();
+		$this->CI->load->helper('url');
+		$this->CI->load->helper('string');
+		$this->CI->load->helper('email');
+		$this->CI->load->helper('language');
+		$this->CI->load->helper('recaptchalib');
+		$this->CI->lang->load('aauth');
 
 
-    ########################
-    # Login Functions
-    ########################
+		// config/aauth.php
+		$this->CI->config->load('aauth');
+		$this->config_vars = $this->CI->config->item('aauth');
+		
+		// load error and info messages from flashdata (but don't store back in flashdata)
+		$this->errors = $this->CI->session->flashdata('errors');
+		$this->infos = $this->CI->session->flashdata('infos');
+	}
 
-    //tested
-    /**
-     * Login user
-     * Check provided details against the database. Add items to error array on fail, create session if success
-     * @param string $email
-     * @param string $pass
-     * @param bool $remember
-     * @return bool Indicates successful login.
-     */
-    public function login($email, $pass, $remember = FALSE) {
 
-        // Remove cookies first
-        $cookie = array(
-            'name'   => 'user',
-            'value'  => '',
-            'expire' => time()-3600,
-            'path'   => '/',
-        );
+	########################
+	# Login Functions
+	########################
 
-        $this->CI->input->set_cookie($cookie);
+	//tested
+	/**
+	 * Login user
+	 * Check provided details against the database. Add items to error array on fail, create session if success
+	 * @param string $email
+	 * @param string $pass
+	 * @param bool $remember
+	 * @return bool Indicates successful login.
+	 */
+	public function login($email, $pass, $remember = FALSE) {
+
+		// Remove cookies first
+		$cookie = array(
+			'name'	 => 'user',
+			'value'	 => '',
+			'expire' => time()-3600,
+			'path'	 => '/',
+		);
+
+		$this->CI->input->set_cookie($cookie);
 
  
-        /*
-        *
-        * User Verification
-        *
-        * Removed or !ctype_alnum($pass) from the IF statement
-        * It was causing issues with special characters in passwords
-        * and returning false even if the password matches.
-        */
-        if( !valid_email($email) or strlen($pass) < 5 or
-            strlen($pass) > $this->config_vars['max'] )
-        {
-            $this->error($this->CI->lang->line('wrong'));
-            return false;
-        }
+		/*
+		*
+		* User Verification
+		*
+		* Removed or !ctype_alnum($pass) from the IF statement
+		* It was causing issues with special characters in passwords
+		* and returning false even if the password matches.
+		*/
+		if( !valid_email($email) or strlen($pass) < 5 or
+			strlen($pass) > $this->config_vars['max'] )
+		{
+			$this->error($this->CI->lang->line('aauth_error_login_failed'));
+			return false;
+		}
 
 
-        $query = null;
-        $query = $this->CI->db->where('email', $email);
-        $query = $this->CI->db->get($this->config_vars['users']);
-        $row = $query->row();
+		$query = null;
+		$query = $this->CI->db->where('email', $email);
+		$query = $this->CI->db->get($this->config_vars['users']);
+		$row = $query->row();
 
-        // only email found and login attempts exceeded
-        if ($query->num_rows() > 0 and $this->config_vars['ddos_protection'] and ! $this->update_login_attempts($row->email)) {
+		// only email found and login attempts exceeded
+		if ($query->num_rows() > 0 && $this->config_vars['ddos_protection'] && ! $this->update_login_attempts($row->email)) {
 
-            $this->error($this->CI->lang->line('exceeded'));
-            return false;
-        }
+			$this->error($this->CI->lang->line('aauth_error_login_attempts_exceeded'));
+			return false;
+		}
 
-        //recaptcha login_attempts check
-        $query = null;
-        $query = $this->CI->db->where('email', $email);
-        $query = $this->CI->db->get($this->config_vars['users']);
-        $row = $query->row();
-        if($query->num_rows() > 0 and $this->config_vars['ddos_protection'] and $this->config_vars['recaptcha_active'] and $row->login_attempts >= $this->config_vars['recaptcha_login_attempts']){
-            $reCAPTCHA_cookie = array(
-                'name'   => 'reCAPTCHA',
-                'value'  => 'true',
-                'expire' => time()+7200,
-                'path'   => '/',
-            );
-            $this->CI->input->set_cookie($reCAPTCHA_cookie);
-        }
+		//recaptcha login_attempts check
+		$query = null;
+		$query = $this->CI->db->where('email', $email);
+		$query = $this->CI->db->get($this->config_vars['users']);
+		$row = $query->row();
+		if($query->num_rows() > 0 && $this->config_vars['ddos_protection'] && $this->config_vars['recaptcha_active'] && $row->login_attempts >= $this->config_vars['recaptcha_login_attempts']){
+			$reCAPTCHA_cookie = array(
+				'name'	 => 'reCAPTCHA',
+				'value'	 => 'true',
+				'expire' => time()+7200,
+				'path'	 => '/',
+			);
+			$this->CI->input->set_cookie($reCAPTCHA_cookie);
+		}
 
-        // if user is not verified
-        $query = null;
-        $query = $this->CI->db->where('email', $email);
-        $query = $this->CI->db->where('banned', 1);
-        $query = $this->CI->db->where('verification_code !=', '');
-        $query = $this->CI->db->get($this->config_vars['users']);
+		// if user is not verified
+		$query = null;
+		$query = $this->CI->db->where('email', $email);
+		$query = $this->CI->db->where('banned', 1);
+		$query = $this->CI->db->where('verification_code !=', '');
+		$query = $this->CI->db->get($this->config_vars['users']);
 
-        if ($query->num_rows() > 0) {
-            $this->error($this->CI->lang->line('not_verified'));
-            return false;
-        }
+		if ($query->num_rows() > 0) {
+			$this->error($this->CI->lang->line('aauth_error_account_not_verified'));
+			return false;
+		}
 
-        // to find user id, create sessions and cookies
-        $query = $this->CI->db->where('email', $email);
-        $query = $this->CI->db->get($this->config_vars['users']);
-        
-        if($query->num_rows() == 0){
-            $this->error($this->CI->lang->line('wrong'));
-            return false;
-        }
-        
-        $user_id = $query->row()->id;
-        
-        $query = null;
-        $query = $this->CI->db->where('email', $email);
+		// to find user id, create sessions and cookies
+		$query = $this->CI->db->where('email', $email);
+		$query = $this->CI->db->get($this->config_vars['users']);
+		
+		if($query->num_rows() == 0){
+			$this->error($this->CI->lang->line('aauth_error_login_failed'));
+			return false;
+		}
+		
+		$user_id = $query->row()->id;
+		
+		$query = null;
+		$query = $this->CI->db->where('email', $email);
 
-        // Database stores pasword hashed password
-        $query = $this->CI->db->where('pass', $this->hash_password($pass, $user_id));
-        $query = $this->CI->db->where('banned', 0);
+		// Database stores pasword hashed password
+		$query = $this->CI->db->where('pass', $this->hash_password($pass, $user_id));
+		$query = $this->CI->db->where('banned', 0);
 
-        $query = $this->CI->db->get($this->config_vars['users']);
+		$query = $this->CI->db->get($this->config_vars['users']);
 
-        $row = $query->row();
-        if($this->CI->input->cookie('reCAPTCHA', TRUE) == 'true'){
-            $reCaptcha = new ReCaptcha( $this->config_vars['recaptcha_secret']);
-            $resp = $reCaptcha->verifyResponse( $this->CI->input->server("REMOTE_ADDR"), $this->CI->input->post("g-recaptcha-response") );
+		$row = $query->row();
+		if($this->CI->input->cookie('reCAPTCHA', TRUE) == 'true'){
+			$reCaptcha = new ReCaptcha( $this->config_vars['recaptcha_secret']);
+			$resp = $reCaptcha->verifyResponse( $this->CI->input->server("REMOTE_ADDR"), $this->CI->input->post("g-recaptcha-response") );
 
-            if(!$resp->success){
-                $this->error($this->CI->lang->line('recaptcha_not_correct'));
-                return false;
-            }
-        }
-     
-        // if email and pass matches and not banned
-        if ( $query->num_rows() > 0 ) {
+			if(!$resp->success){
+				$this->error($this->CI->lang->line('aauth_error_recaptcha_not_correct'));
+				return false;
+			}
+		}
+	 
+		// if email and pass matches and not banned
+		if ( $query->num_rows() > 0 ) {
 
-            // If email and pass matches
-            // create session
-            $data = array(
-                'id' => $row->id,
-                'name' => $row->name,
-                'email' => $row->email,
-                'loggedin' => TRUE
-            );
+			// If email and pass matches
+			// create session
+			$data = array(
+				'id' => $row->id,
+				'name' => $row->name,
+				'email' => $row->email,
+				'loggedin' => TRUE
+			);
 
-            $this->CI->session->set_userdata($data);
+			$this->CI->session->set_userdata($data);
 
-            // if remember selected
-            if ( $remember ){
-                $expire = $this->config_vars['remember'];
-                $today = date("Y-m-d");
-                $remember_date = date("Y-m-d", strtotime($today . $expire) );
-                $random_string = random_string('alnum', 16);
-                $this->update_remember($row->id, $random_string, $remember_date );
+			// if remember selected
+			if ( $remember ){
+				$expire = $this->config_vars['remember'];
+				$today = date("Y-m-d");
+				$remember_date = date("Y-m-d", strtotime($today . $expire) );
+				$random_string = random_string('alnum', 16);
+				$this->update_remember($row->id, $random_string, $remember_date );
 
-                $cookie = array(
-                    'name'   => 'user',
-                    'value'  => $row->id . "-" . $random_string,
-                    'expire' => time() + 99*999*999,
-                    'path'   => '/',
-                );
+				$cookie = array(
+					'name'	 => 'user',
+					'value'	 => $row->id . "-" . $random_string,
+					'expire' => time() + 99*999*999,
+					'path'	 => '/',
+				);
 
-                $this->CI->input->set_cookie($cookie);
-            }
+				$this->CI->input->set_cookie($cookie);
+			}
 
-            $reCAPTCHA_cookie = array(
-                'name'   => 'reCAPTCHA',
-                'value'  => 'false',
-                'expire' => time()-3600,
-                'path'   => '/',
-            );
-            $this->CI->input->set_cookie($reCAPTCHA_cookie);
+			$reCAPTCHA_cookie = array(
+				'name'	 => 'reCAPTCHA',
+				'value'	 => 'false',
+				'expire' => time()-3600,
+				'path'	 => '/',
+			);
+			$this->CI->input->set_cookie($reCAPTCHA_cookie);
 
-            // update last login
-            $this->update_last_login($row->id);
-            $this->update_activity();
-            $this->reset_login_attempts($row->id);
-            
-            return TRUE;
-        }
-        // if not matches
-        else {
+			// update last login
+			$this->update_last_login($row->id);
+			$this->update_activity();
+			$this->reset_login_attempts($row->id);
+			
+			return TRUE;
+		}
+		// if not matches
+		else {
 
-            $this->error($this->CI->lang->line('wrong'));
-            return FALSE;
-        }
-    }
+			$this->error($this->CI->lang->line('aauth_error_login_failed'));
+			return FALSE;
+		}
+	}
 
-    //tested
-    /**
-     * Check user login
-     * Checks if user logged in, also checks remember.
-     * @return bool
-     */
-    public function is_loggedin() {
+	//tested
+	/**
+	 * Check user login
+	 * Checks if user logged in, also checks remember.
+	 * @return bool
+	 */
+	public function is_loggedin() {
 
-        if ( $this->CI->session->userdata('loggedin') )
-        { return true; }
+		if ( $this->CI->session->userdata('loggedin') )
+		{ return true; }
 
-        // cookie control
-        else {
-            if( ! $this->CI->input->cookie('user', TRUE) ){
-                return false;
-            } else {
-                $cookie = explode('-', $this->CI->input->cookie('user', TRUE));
-                if(!is_numeric( $cookie[0] ) or strlen($cookie[1]) < 13 ){return false;}
-                else{
-                    $query = $this->CI->db->where('id', $cookie[0]);
-                    $query = $this->CI->db->where('remember_exp', $cookie[1]);
-                    $query = $this->CI->db->get($this->config_vars['users']);
+		// cookie control
+		else {
+			if( ! $this->CI->input->cookie('user', TRUE) ){
+				return false;
+			} else {
+				$cookie = explode('-', $this->CI->input->cookie('user', TRUE));
+				if(!is_numeric( $cookie[0] ) or strlen($cookie[1]) < 13 ){return false;}
+				else{
+					$query = $this->CI->db->where('id', $cookie[0]);
+					$query = $this->CI->db->where('remember_exp', $cookie[1]);
+					$query = $this->CI->db->get($this->config_vars['users']);
 
-                    $row = $query->row();
+					$row = $query->row();
 
-                    if ($query->num_rows() < 1) {
-                        $this->update_remember($cookie[0]);
-                        return false;
-                    }else{
+					if ($query->num_rows() < 1) {
+						$this->update_remember($cookie[0]);
+						return false;
+					}else{
 
-                        if(strtotime($row->remember_time) > strtotime("now") ){
-                            $this->login_fast($cookie[0]);
-                            return true;
-                        }
-                        // if time is expired
-                        else {
-                            return false;
-                        }
-                    }
-                }
+						if(strtotime($row->remember_time) > strtotime("now") ){
+							$this->login_fast($cookie[0]);
+							return true;
+						}
+						// if time is expired
+						else {
+							return false;
+						}
+					}
+				}
 
-            }
-        }
+			}
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * Controls if a logged or public user has permission
-     * 
-     * If user does not have permission to access page, it stops script and gives
-     * error message, unless 'no_permission' value is set in config.  If 'no_permission' is
-     * set in config it redirects user to the set url and passes the 'no_access' error message.
-     * It also updates last activity every time function called.
-     *
-     * @param bool $perm_par If not given just control user logged in or not
-     */
-    public function control( $perm_par = false ){
+	/**
+	 * Controls if a logged or public user has permission
+	 * 
+	 * If user does not have permission to access page, it stops script and gives
+	 * error message, unless 'no_permission' value is set in config.  If 'no_permission' is
+	 * set in config it redirects user to the set url and passes the 'no_access' error message.
+	 * It also updates last activity every time function called.
+	 *
+	 * @param bool $perm_par If not given just control user logged in or not
+	 */
+	public function control( $perm_par = false ){
 
 		$perm_id = $this->get_perm_id($perm_par);
 		$this->update_activity();
 
-        // if user or user's group not allowed
-        if ( ! $this->is_allowed($perm_id) or ! $this->is_group_allowed($perm_id) ){
-            if( $this->config_vars['no_permission'] ) {
-            	$this->error($this->CI->lang->line('no_access'));
-            	redirect($this->config_vars['no_permission']);
-            }
-            else {
-				echo $this->CI->lang->line('no_access');
+		// if user or user's group not allowed
+		if ( ! $this->is_allowed($perm_id) or ! $this->is_group_allowed($perm_id) ){
+			if( $this->config_vars['no_permission'] ) {
+				$this->error($this->CI->lang->line('aauth_error_no_access'));
+				redirect($this->config_vars['no_permission']);
+			}
+			else {
+				echo $this->CI->lang->line('aauth_error_no_access');
 				die();
 			}
-        }
-    }
-
-    //tested
-    /**
-     * Logout user
-     * Destroys the CodeIgniter session and remove cookies to log out user.
-     * @return bool If session destroy successful
-     */
-    public function logout() {
-
-        $cookie = array(
-            'name'   => 'user',
-            'value'  => '',
-            'expire' => time()-3600,
-            'path'   => '/',
-        );
-
-        $this->CI->input->set_cookie($cookie);
-
-        return $this->CI->session->sess_destroy();
-    }
-
-    //tested
-    /**
-     * Fast login
-     * Login with just a user id
-     * @param int $user_id User id to log in
-     * @return bool true if login successful.
-     */
-    public function login_fast($user_id){
-
-        $query = $this->CI->db->where('id', $user_id);
-        $query = $this->CI->db->where('banned', 0);
-        $query = $this->CI->db->get($this->config_vars['users']);
-
-        $row = $query->row();
-
-        if ($query->num_rows() > 0) {
-
-            // if id matches
-            // create session
-            $data = array(
-                'id' => $row->id,
-                'name' => $row->name,
-                'email' => $row->email,
-                'loggedin' => TRUE
-            );
-
-            $this->CI->session->set_userdata($data);
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * Reset last login attempts
-     * Sets a users 'last login attempts' to null
-     * @param int $user_id User id to reset
-     * @return bool Reset fails/succeeds
-     */
-    public  function reset_login_attempts($user_id) {
-
-        $data['login_attempts'] = null;
-        $this->CI->db->where('id', $user_id);
-        return $this->CI->db->update($this->config_vars['users'], $data);
-    }
-
-    /**
-     * Remind password
-     * Emails user with link to reset password
-     * @param string $email Email for account to remind
-     */
-    public function remind_password($email){
-
-        $query = $this->CI->db->where( 'email', $email );
-        $query = $this->CI->db->get( $this->config_vars['users'] );
-
-        if ($query->num_rows() > 0){
-            $row = $query->row();
-
-            $ver_code = random_string('alnum', 16);
-
-            $data['verification_code'] = $ver_code;
-
-            $this->CI->db->where('email', $email);
-            $this->CI->db->update($this->config_vars['users'], $data);
-
-            $this->CI->email->from( $this->config_vars['email'], $this->config_vars['name']);
-            $this->CI->email->to($row->email);
-            $this->CI->email->subject($this->CI->lang->line('reset'));
-            $this->CI->email->message($this->CI->lang->line('remind') . ' ' .
-            $this->CI->lang->line('remind') . $row->id . '/' . $ver_code );
-            $this->CI->email->send();
-        }
-    }
-
-    /**
-     * Reset password
-     * Generate new password and email it to the user
-     * @param int $user_id User id to reset password for
-     * @param string $ver_code Verification code for account
-     * @return bool Password reset fails/succeeds
-     */
-    public function reset_password($user_id, $ver_code){
+		}
+	}
+
+	//tested
+	/**
+	 * Logout user
+	 * Destroys the CodeIgniter session and remove cookies to log out user.
+	 * @return bool If session destroy successful
+	 */
+	public function logout() {
+
+		$cookie = array(
+			'name'	 => 'user',
+			'value'	 => '',
+			'expire' => time()-3600,
+			'path'	 => '/',
+		);
+
+		$this->CI->input->set_cookie($cookie);
+
+		return $this->CI->session->sess_destroy();
+	}
+
+	//tested
+	/**
+	 * Fast login
+	 * Login with just a user id
+	 * @param int $user_id User id to log in
+	 * @return bool true if login successful.
+	 */
+	public function login_fast($user_id){
+
+		$query = $this->CI->db->where('id', $user_id);
+		$query = $this->CI->db->where('banned', 0);
+		$query = $this->CI->db->get($this->config_vars['users']);
+
+		$row = $query->row();
+
+		if ($query->num_rows() > 0) {
+
+			// if id matches
+			// create session
+			$data = array(
+				'id' => $row->id,
+				'name' => $row->name,
+				'email' => $row->email,
+				'loggedin' => TRUE
+			);
+
+			$this->CI->session->set_userdata($data);
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Reset last login attempts
+	 * Sets a users 'last login attempts' to null
+	 * @param int $user_id User id to reset
+	 * @return bool Reset fails/succeeds
+	 */
+	public	function reset_login_attempts($user_id) {
+
+		$data['login_attempts'] = null;
+		$this->CI->db->where('id', $user_id);
+		return $this->CI->db->update($this->config_vars['users'], $data);
+	}
+
+	/**
+	 * Remind password
+	 * Emails user with link to reset password
+	 * @param string $email Email for account to remind
+	 */
+	public function remind_password($email){
+
+		$query = $this->CI->db->where( 'email', $email );
+		$query = $this->CI->db->get( $this->config_vars['users'] );
+
+		if ($query->num_rows() > 0){
+			$row = $query->row();
+
+			$ver_code = random_string('alnum', 16);
+
+			$data['verification_code'] = $ver_code;
+
+			$this->CI->db->where('email', $email);
+			$this->CI->db->update($this->config_vars['users'], $data);
+
+			$this->CI->email->from( $this->config_vars['email'], $this->config_vars['name']);
+			$this->CI->email->to($row->email);
+			$this->CI->email->subject($this->CI->lang->line('aauth_email_reset_subject'));
+			$this->CI->email->message($this->CI->lang->line('aauth_email_reset_link') . $row->id . '/' . $ver_code );
+			$this->CI->email->send();
+		}
+	}
+
+	/**
+	 * Reset password
+	 * Generate new password and email it to the user
+	 * @param int $user_id User id to reset password for
+	 * @param string $ver_code Verification code for account
+	 * @return bool Password reset fails/succeeds
+	 */
+	public function reset_password($user_id, $ver_code){
 
-        $query = $this->CI->db->where('id', $user_id);
-        $query = $this->CI->db->where('verification_code', $ver_code);
-        $query = $this->CI->db->get( $this->config_vars['users'] );
+		$query = $this->CI->db->where('id', $user_id);
+		$query = $this->CI->db->where('verification_code', $ver_code);
+		$query = $this->CI->db->get( $this->config_vars['users'] );
 
-        $pass = random_string('alnum',8);
+		$pass = random_string('alnum',8);
 
-        if( $query->num_rows() > 0 ){
+		if( $query->num_rows() > 0 ){
 
-            $data =  array(
-                'verification_code' => '',
-                'pass' => $this->hash_password($pass, $user_id)
-            );
+			$data =	 array(
+				'verification_code' => '',
+				'pass' => $this->hash_password($pass, $user_id)
+			);
 
-            $row = $query->row();
-            $email = $row->email;
+			$row = $query->row();
+			$email = $row->email;
 
-            $this->CI->db->where('id', $user_id);
-            $this->CI->db->update($this->config_vars['users'] , $data);
+			$this->CI->db->where('id', $user_id);
+			$this->CI->db->update($this->config_vars['users'] , $data);
 
-            $this->CI->email->from( $this->config_vars['email'], $this->config_vars['name']);
-            $this->CI->email->to($email);
-            $this->CI->email->subject($this->CI->lang->line('reset'));
-            $this->CI->email->message($this->CI->lang->line('new_password') . $pass);
-            $this->CI->email->send();
+			$this->CI->email->from( $this->config_vars['email'], $this->config_vars['name']);
+			$this->CI->email->to($email);
+			$this->CI->email->subject($this->CI->lang->line('aauth_email_reset_success_subject'));
+			$this->CI->email->message($this->CI->lang->line('aauth_email_reset_success_new_password') . $pass);
+			$this->CI->email->send();
 
-            return true;
-        }
+			return true;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    //tested
-    /**
-     * Update last login
-     * Update user's last login date
-     * @param int|bool $user_id User id to update or false for current user
-     * @return bool Update fails/succeeds
-     */
-    public function update_last_login($user_id = FALSE) {
-
-        if ($user_id == FALSE)
-            $user_id = $this->CI->session->userdata('id');
-
-        $data['last_login'] = date("Y-m-d H:i:s");
-        $data['ip_address'] = $this->CI->input->ip_address();
-
-        $this->CI->db->where('id', $user_id);
-        return $this->CI->db->update($this->config_vars['users'], $data);
-    }
-
-
-    //tested
-    /**
-     * Update login attempt and if exceeds return false
-     * Update user's last login attemp date and number date
-     * @param string $email User email
-     * @return bool
-     */
-    public function update_login_attempts($email) {
-
-        $user_id = $this->get_user_id($email);
-
-        $query = $this->CI->db->where('id', $user_id);
-        $query = $this->CI->db->get( $this->config_vars['users'] );
-        $row = $query->row();
-
-
-        $data = array();
-
-        if ( strtotime($row->last_login_attempt) == strtotime(date("Y-m-d H:0:0"))) {
-            $data['login_attempts'] = $row->login_attempts + 1;
-
-            $query = $this->CI->db->where('id', $user_id);
-            $this->CI->db->update($this->config_vars['users'], $data);
-
-        } else {
-
-            $data['last_login_attempt'] = date("Y-m-d H:0:0");
-            $data['login_attempts'] = 1;
-
-            $this->CI->db->where('id', $user_id);
-            $this->CI->db->update($this->config_vars['users'], $data);
-
-        }
-
-        if ( $data['login_attempts'] > $this->config_vars['max_login_attempt'] ) {
-            return false;
-        } else {
-            return true;
-        }
-
-    }
-
-    /**
-     * Update remember
-     * Update amount of time a user is remembered for
-     * @param int $user_id User id to update 
-     * @param int $expression
-     * @param int $expire 
-     * @return bool Update fails/succeeds
-     */
-    public function update_remember($user_id, $expression=null, $expire=null) {
-
-        $data['remember_time'] = $expire;
-        $data['remember_exp'] = $expression;
-
-        $query = $this->CI->db->where('id',$user_id);
-        return $this->CI->db->update($this->config_vars['users'], $data);
-    }
-
-
-    ########################
-    # User Functions
-    ########################
-
-    //tested
-    /**
-     * Create user
-     * Creates a new user
-     * @param string $email User's email address
-     * @param string $pass User's password
-     * @param string $name User's name
-     * @return int|bool False if create fails or returns user id if successful
-     */
-    public function create_user($email, $pass, $name) {
-
-        $valid = true;
-
-        // if email is already exist
-        if ($this->user_exsist_by_email($email)) {
-            $this->error($this->CI->lang->line('email_taken'));
-            $valid = false;
-        }
-        if ($this->user_exsist_by_name($name)) {
-            $this->error($this->CI->lang->line('name_taken'));
-            $valid = false;
-        }
-
-        if ( ! valid_email($email)){
-            $this->error($this->CI->lang->line('email_invalid'));
-            $valid = false;
-        }
-        if ( strlen($pass) < 5 or strlen($pass) > $this->config_vars['max'] ){
-            $this->error($this->CI->lang->line('pass_invalid'));
-            $valid = false;
-        }
-        if ($name !='' and !ctype_alnum(str_replace($this->config_vars['valid_chars'], '', $name))){
-            $this->error($this->CI->lang->line('name_invalid'));
-            $valid = false;
-        }
-        if (empty($name)){
-            $this->error($this->CI->lang->line('name_invalid'));
-            $valid = false;
-        }
-
-        if (!$valid) {
-            return false; }
-
-        $data = array(
-            'email' => $email,
-            'pass' => $this->hash_password($pass, 0), // Password cannot be blank but user_id required for salt, setting bad password for now
-            'name' => $name,
-        );
-
-        if ( $this->CI->db->insert($this->config_vars['users'], $data )){
-
-            $user_id = $this->CI->db->insert_id();
-
-            // set default group
-            $this->add_member($user_id, $this->config_vars['default_group']);
-
-            // if verification activated
-            if($this->config_vars['verification']){
-                $data = null;
-                $data['banned'] = 1;
-
-                $this->CI->db->where('id', $user_id);
-                $this->CI->db->update($this->config_vars['users'], $data);
-
-                // sends verifition ( !! e-mail settings must be set)
-                $this->send_verification($user_id);
-            }
-
-            // Update to correct salted password
-            $data = null;
-            $data['pass'] = $this->hash_password($pass, $user_id);
-            $this->CI->db->where('id', $user_id);
-            $this->CI->db->update($this->config_vars['users'], $data);
-
-            return $user_id;
-
-        } else {
-            return FALSE;
-        }
-    }
-
-    //tested
-    /**
-     * Update user
-     * Updates existing user details
-     * @param int $user_id User id to update
-     * @param string|bool $email User's email address, or false if not to be updated
-     * @param string|bool $pass User's password, or false if not to be updated
-     * @param string|bool $name User's name, or false if not to be updated
-     * @return bool Update fails/succeeds
-     */
-    public function update_user($user_id, $email = FALSE, $pass = FALSE, $name = FALSE) {
-
-        $data = array();
-
-        if ($email != FALSE) {
-            $data['email'] = $email;
-        }
-
-        if ($pass != FALSE) {
-            $data['pass'] = $this->hash_password($pass, $user_id);
-        }
-
-        if ($name != FALSE) {
-            $data['name'] = $name;
-        }
-
-        $this->CI->db->where('id', $user_id);
-        return $this->CI->db->update($this->config_vars['users'], $data);
-    }
-
-    //tested
-    /**
-     * List users
-     * Return users as an object array
-     * @param bool|int $group_par Specify group id to list group or false for all users
-     * @param string $limit Limit of users to be returned
-     * @param bool $offset Offset for limited number of users
-     * @param bool $include_banneds Include banned users
-     * @return array Array of users
-     */
-    public function list_users($group_par = FALSE, $limit = FALSE, $offset = FALSE, $include_banneds = FALSE) {
-
-        // if group_par is given
-        if ($group_par != FALSE) {
-
-            $group_par = $this->get_group_id($group_par);
-            $this->CI->db->select('*')
-                ->from($this->config_vars['users'])
-                ->join($this->config_vars['user_to_group'], $this->config_vars['users'] . ".id = " . $this->config_vars['user_to_group'] . ".user_id")
-                ->where($this->config_vars['user_to_group'] . ".group_id", $group_par);
-
-            // if group_par is not given, lists all users
-        } else {
-
-            $this->CI->db->select('*')
-                ->from($this->config_vars['users']);
-        }
-
-        // banneds
-        if (!$include_banneds) {
-            $this->CI->db->where('banned != ', 1);
-        }
-
-        // limit
-        if ($limit) {
-
-            if ($offset == FALSE)
-                $this->CI->db->limit($limit);
-            else
-                $this->CI->db->limit($limit, $offset);
-        }
-
-        $query = $this->CI->db->get();
-
-        return $query->result();
-    }
-
-    //tested
-    /**
-     * Get user
-     * Get user information
-     * @param int|bool $user_id User id to get or false for current user
-     * @return object User information
-     */
-    public function get_user($user_id = FALSE) {
-
-        if ($user_id == FALSE)
-            $user_id = $this->CI->session->userdata('id');
-
-        $query = $this->CI->db->where('id', $user_id);
-        $query = $this->CI->db->get($this->config_vars['users']);
-
-        if ($query->num_rows() <= 0){
-            $this->error($this->CI->lang->line('no_user'));
-            return FALSE;
-        }
-        return $query->row();
-    }
-
-    /**
-     * Verify user
-     * Activates user account based on verification code
-     * @param int $user_id User id to activate
-     * @param string $ver_code Code to validate against
-     * @return bool Activation fails/succeeds
-     */
-    public function verify_user($user_id, $ver_code){
-
-        $query = $this->CI->db->where('id', $user_id);
-        $query = $this->CI->db->where('verification_code', $ver_code);
-        $query = $this->CI->db->get( $this->config_vars['users'] );
-
-        // if ver code is true
-        if( $query->num_rows() > 0 ){
-
-            $data =  array(
-                'verification_code' => '',
-                'banned' => 0
-            );
-
-            $this->CI->db->where('id', $user_id);
-            $this->CI->db->update($this->config_vars['users'] , $data);
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * Send verification email
-     * Sends a verification email based on user id
-     * @param int $user_id User id to send verification email to
-     * @todo return success indicator
-     */
-    public function send_verification($user_id){
-
-        $query = $this->CI->db->where( 'id', $user_id );
-        $query = $this->CI->db->get( $this->config_vars['users'] );
-
-        if ($query->num_rows() > 0){
-            $row = $query->row();
-
-            $ver_code = random_string('alnum', 16);
-
-            $data['verification_code'] = $ver_code;
-
-            $this->CI->db->where('id', $user_id);
-            $this->CI->db->update($this->config_vars['users'], $data);
-
-            $this->CI->email->from( $this->config_vars['email'], $this->config_vars['name']);
-            $this->CI->email->to($row->email);
-            $this->CI->email->subject($this->CI->lang->line('verification_subject'));
-            $this->CI->email->message($this->CI->lang->line('code') . $ver_code .
-                $this->CI->lang->line('link') . $user_id . '/' . $ver_code );
-            $this->CI->email->send();
-        }
-    }
-
-    //not tested excatly
-    /**
-     * Delete user
-     * Delete a user from database. WARNING Can't be undone
-     * @param int $user_id User id to delete
-     */
-    public function delete_user($user_id) {
-
-        $this->CI->db->where('id', $user_id);
-        $this->CI->db->delete($this->config_vars['users']);
-
-        // delete from perm_to_user
-        $this->CI->db->where('user_id', $user_id);
-        $this->CI->db->delete($this->config_vars['perm_to_user']);
-
-        // delete from user_to_group
-        $this->CI->db->where('user_id', $user_id);
-        $this->CI->db->delete($this->config_vars['user_to_group']);
-
-        // delete user vars
-        $this->CI->db->where('user_id', $user_id);
-        $this->CI->db->delete($this->config_vars['user_variables']);
-    }
-
-    //tested
-    /**
-     * Ban user
-     * Bans a user account
-     * @param int $user_id User id to ban
-     * @return bool Ban fails/succeeds
-     */
-    public function ban_user($user_id) {
-
-        $data = array(
-            'banned' => 1,
-            'verification_code' => ''
-        );
-
-        $this->CI->db->where('id', $user_id);
-
-        return $this->CI->db->update($this->config_vars['users'], $data);
-    }
-
-    //tested
-    /**
-     * Unban user
-     * Activates user account
-     * Same with unlock_user()
-     * @param int $user_id User id to activate
-     * @return bool Activation fails/succeeds
-     */
-    public function unban_user($user_id) {
-
-        $data = array(
-            'banned' => 0
-        );
-
-        $this->CI->db->where('id', $user_id);
-
-        return $this->CI->db->update($this->config_vars['users'], $data);
-    }
-
-    //tested
-    /**
-     * Check user banned
-     * Checks if a user is banned
-     * @param int $user_id User id to check
-     * @return bool False if banned, True if not
-     */
-    public function is_banned($user_id) {
-
-        $query = $this->CI->db->where('id', $user_id);
-        $query = $this->CI->db->where('banned', 1);
-
-        $query = $this->CI->db->get($this->config_vars['users']);
-
-        if ($query->num_rows() > 0)
-            return TRUE;
-        else
-            return FALSE;
-    }
-
-    /**
-     * user_exsist_by_id
-     * Check if user exist by user id
-     * @param $user_id
-     *
-     * @return bool
-     */
-    public function user_exsist_by_id( $user_id ) {
-        $query = $this->CI->db->where('id', $user_id);
-
-        $query = $this->CI->db->get($this->config_vars['users']);
-
-        if ($query->num_rows() > 0)
-            return TRUE;
-        else
-            return FALSE;
-    }
-
-    /**
-     * user_exsist_by_name
-     * Check if user exist by name
-     * @param $user_id
-     *
-     * @return bool
-     */
-    public function user_exsist_by_name( $name ) {
-        $query = $this->CI->db->where('name', $name);
-
-        $query = $this->CI->db->get($this->config_vars['users']);
-
-        if ($query->num_rows() > 0)
-            return TRUE;
-        else
-            return FALSE;
-    }
-
-    /**
-     * user_exsist_by_email
-     * Check if user exsist by user email
-     * @param $user_email
-     *
-     * @return bool
-     */
-    public function user_exsist_by_email( $user_email ) {
-        $query = $this->CI->db->where('email', $user_email);
-
-        $query = $this->CI->db->get($this->config_vars['users']);
-
-        if ($query->num_rows() > 0)
-            return TRUE;
-        else
-            return FALSE;
-    }
-
-    /**
-     * Get user id
-     * Get user id from email address, if par. not given, return current user's id
-     * @param string|bool $email Email address for user
-     * @return int User id
-     */
-    public function get_user_id($email=false) {
-
-        if( ! $email){
-            $query = $this->CI->db->where('id', $this->CI->session->userdata('id'));
-        } else {
-            $query = $this->CI->db->where('email', $email);
-        }
-
-        $query = $this->CI->db->get($this->config_vars['users']);
-
-        if ($query->num_rows() <= 0){
-            $this->error($this->CI->lang->line('no_user'));
-            return FALSE;
-        }
-        return $query->row()->id;
-    }
-
-    /**
-     * Get user groups
-     * Get groups a user is in
-     * @param int|bool $user_id User id to get or false for current user
-     * @return array Groups
-     */
-    public function get_user_groups($user_id = false){
-
-        if ($user_id==false) { $user_id = $this->CI->session->userdata('id'); }
-
-        $this->CI->db->select('*');
-        $this->CI->db->from($this->config_vars['user_to_group']);
-        $this->CI->db->join($this->config_vars['groups'], "id = group_id");
-        $this->CI->db->where('user_id', $user_id);
-
-        return $query = $this->CI->db->get()->result();
-    }
-
-    //tested
-    /**
-     * Update activity
-     * Update user's last activity date
-     * @param int|bool $user_id User id to update or false for current user
-     * @return bool Update fails/succeeds
-     */
-    public function update_activity($user_id = FALSE) {
-
-        if ($user_id == FALSE)
-            $user_id = $this->CI->session->userdata('id');
-
-        if($user_id==false){return false;}
-
-        $data['last_activity'] = date("Y-m-d H:i:s");
-
-        $query = $this->CI->db->where('id',$user_id);
-        return $this->CI->db->update($this->config_vars['users'], $data);
-    }
-
-    //tested
-    /**
-     * Hash password
-     * Hash the password for storage in the database
-     * (thanks to Jacob Tomlinson for contribution)
-     * @param string $pass Password to hash
-     * @param $userid
-     * @return string Hashed password
-     */
-    function hash_password($pass, $userid) {
-
-        $salt = md5($userid);
-        return hash('sha256', $salt.$pass);
-    }
-
-    ########################
-    # Group Functions
-    ########################
-
-    //tested
-    /**
-     * Create group
-     * Creates a new group
-     * @param string $group_name New group name
-     * @return int|bool Group id or false on fail
-     */
-    public function create_group($group_name) {
-
-        $query = $this->CI->db->get_where($this->config_vars['groups'], array('name' => $group_name));
-
-        if ($query->num_rows() < 1) {
-
-            $data = array(
-                'name' => $group_name
-            );
-            $this->CI->db->insert($this->config_vars['groups'], $data);
-            return $this->CI->db->insert_id();
-        }
-
-        $this->error($this->CI->lang->line('group_exist'));
-        return FALSE;
-    }
-
-    //tested
-    /**
-     * Update group
-     * Change a groups name
-     * @param int $group_id Group id to update
-     * @param string $group_name New group name
-     * @return bool Update success/failure
-     */
-    public function update_group($group_par, $group_name) {
-
-        $group_id = $this->get_group_id($group_par);
-
-        $data['name'] = $group_name;
-
-        $this->CI->db->where('id', $group_id);
-        return $this->CI->db->update($this->config_vars['groups'], $data);
-    }
-
-    //tested
-    /**
-     * Delete group
-     * Delete a group from database. WARNING Can't be undone
-     * @param int $group_id User id to delete
-     * @return bool Delete success/failure
-     */
-    public function delete_group($group_par) {
-
-        $group_id = $this->get_group_id($group_par);
-        
-    $this->CI->db->where('id',$group_id);
-    $query = $this->CI->db->get($this->config_vars['groups']);
-    if ($query->num_rows() == 0){
-        return false;
-    }
-
-        // bug fixed
-        // now users are deleted from user_to_group table
-        $this->CI->db->where('group_id', $group_id);
-        $this->CI->db->delete($this->config_vars['user_to_group']);
-
-        $this->CI->db->where('id', $group_id);
-        return $this->CI->db->delete($this->config_vars['groups']);
-    }
-
-    //tested
-    /**
-     * Add member
-     * Add a user to a group
-     * @param int $user_id User id to add to group
-     * @param int|string $group_par Group id or name to add user to
-     * @return bool Add success/failure
-     */
-    public function add_member($user_id, $group_par) {
-
-        $group_id = $this->get_group_id($group_par);
-
-        if( ! $group_id ) {
-
-            $this->error( $this->CI->lang->line('no_group') );
-            return false;
-        }
-
-        $query = $this->CI->db->where('user_id',$user_id);
-        $query = $this->CI->db->where('group_id',$group_id);
-        $query = $this->CI->db->get($this->config_vars['user_to_group']);
-
-        if ($query->num_rows() < 1) {
-            $data = array(
-                'user_id' => $user_id,
-                'group_id' => $group_id
-            );
-
-            return $this->CI->db->insert($this->config_vars['user_to_group'], $data);
-        }
-        $this->info($this->CI->lang->line('already_member'));
-        return true;
-    }
-
-    //tested
-    /**
-     * Remove member
-     * Remove a user from a group
-     * @param int $user_id User id to remove from group
-     * @param int|string $group_par Group id or name to remove user from
-     * @return bool Remove success/failure
-     */
-    public function remove_member($user_id, $group_par) {
-
-        $group_par = $this->get_group_id($group_par);
-        $this->CI->db->where('user_id', $user_id);
-        $this->CI->db->where('group_id', $group_par);
-        return $this->CI->db->delete($this->config_vars['user_to_group']);
-    }
-
-    //tested
-    /**
-     * Is member
-     * Check if current user is a member of a group
-     * @param int|string $group_par Group id or name to check
-     * @param int|bool $user_id User id, if not given current user
-     * @return bool
-     */
-    public function is_member( $group_par, $user_id = false ) {
-
-        // if user_id false (not given), current user
-        if( ! $user_id){
-            $user_id = $this->CI->session->userdata('id');
-        }
-
-        $group_id = $this->get_group_id($group_par);
-
-        $query = $this->CI->db->where('user_id', $user_id);
-        $query = $this->CI->db->where('group_id', $group_id);
-        $query = $this->CI->db->get($this->config_vars['user_to_group']);
-
-        $row = $query->row();
-
-        if ($query->num_rows() > 0) {
-            return TRUE;
-        } else {
-            return FALSE;
-        }
-    }
-
-    //tested
-    /**
-     * Is admin
-     * Check if current user is a member of the admin group
-     * @param int $user_id User id to check, if it is not given checks current user
-     * @return bool
-     */
-    public function is_admin( $user_id = false ) {
-
-        return $this->is_member($this->config_vars['admin_group'], $user_id);
-    }
-
-    //tested
-    /**
-     * List groups
-     * List all groups
-     * @return object Array of groups
-     */
-    public function list_groups() {
-
-        $query = $this->CI->db->get($this->config_vars['groups']);
-        return $query->result();
-    }
-
-
-    //tested
-    /**
-     * Get group name
-     * Get group name from group id
-     * @param int $group_id Group id to get
-     * @return string Group name
-     */
-    public function get_group_name($group_id) {
-
-        $query = $this->CI->db->where('id', $group_id);
-        $query = $this->CI->db->get($this->config_vars['groups']);
-
-        if ($query->num_rows() == 0)
-            return FALSE;
-
-        $row = $query->row();
-        return $row->name;
-    }
-
-    //tested
-    /**
-     * Get group id
-     * Get group id from group name or id ( ! Case sensitive)
-     * @param int|string $group_par Group id or name to get
-     * @return int Group id
-     */
-    public function get_group_id ( $group_par ) {
-
-        if( is_numeric($group_par) ) { return $group_par; }
-
-        $query = $this->CI->db->where('name', $group_par);
-        $query = $this->CI->db->get($this->config_vars['groups']);
-
-        if ($query->num_rows() == 0)
-            return FALSE;
-
-        $row = $query->row();
-        return $row->id;
-    }
-
-    ########################
-    # Permission Functions
-    ########################
-
-    //tested
-    /**
-     * Create permission
-     * Creates a new permission type
-     * @param string $perm_name New permission name
-     * @param string $definition Permission description
-     * @return int|bool Permission id or false on fail
-     */
-    public function create_perm($perm_name, $definition='') {
-
-        $query = $this->CI->db->get_where($this->config_vars['perms'], array('name' => $perm_name));
-
-        if ($query->num_rows() < 1) {
-
-            $data = array(
-                'name' => $perm_name,
-                'definition'=> $definition
-            );
-            $this->CI->db->insert($this->config_vars['perms'], $data);
-            return $this->CI->db->insert_id();
-        }
-        $this->error($this->CI->lang->line('already_perm'));
-        return FALSE;
-    }
-
-    //tested
-    /**
-     * Update permission
-     * Updates permission name and description
-     * @param int|string $perm_par Permission id or permission name
-     * @param string $perm_name New permission name
-     * @param string $definition Permission description
-     * @return bool Update success/failure
-     */
-    public function update_perm($perm_par, $perm_name=false, $definition=false) {
-
-        $perm_id = $this->get_perm_id($perm_par);
-
-        if ($perm_name != false)
-            $data['name'] = $perm_name;
-
-        if ($definition != false)
-            $data['definition'] = $definition;
-
-        $this->CI->db->where('id', $perm_id);
-        return $this->CI->db->update($this->config_vars['perms'], $data);
-    }
-
-    //not ok
-    /**
-     * Delete permission
-     * Delete a permission from database. WARNING Can't be undone
-     * @param int|string $perm_par Permission id or perm name to delete
-     * @return bool Delete success/failure
-     */
-    public function delete_perm($perm_par) {
-
-        $perm_id = $this->get_perm_id($perm_par);
-
-        // deletes from perm_to_gropup table
-        $this->CI->db->where('perm_id', $perm_id);
-        $this->CI->db->delete($this->config_vars['perm_to_group']);
-
-        // deletes from perm_to_user table
-        $this->CI->db->where('perm_id', $perm_id);
-        $this->CI->db->delete($this->config_vars['perm_to_group']);
-
-        // deletes from permission table
-        $this->CI->db->where('id', $perm_id);
-        return $this->CI->db->delete($this->config_vars['perms']);
-    }
-
-    /**
-     * Is user allowed
-     * Check if user allowed to do specified action, admin always allowed
-     * first checks user permissions then check group permissions
-     * @param int $perm_par Permission id or name to check
-     * @param int|bool $user_id User id to check, or if false checks current user
-     * @return bool
-     */
-    public function is_allowed($perm_par, $user_id=false){
-
-        $perm_id = $this->get_perm_id($perm_par);
-
-        if( $user_id == false){
-            $user_id = $this->CI->session->userdata('id');
-        }
-
-        $query = $this->CI->db->where('perm_id', $perm_id);
-        $query = $this->CI->db->where('user_id', $user_id);
-        $query = $this->CI->db->get( $this->config_vars['perm_to_user'] );
-
-        if( $query->num_rows() > 0){
-            return true;
-        } elseif ($this->is_group_allowed($perm_id)) {
-            return true;
-        } else {
-            return false;
-        }
-
-    }
-
-    /**
-     * Is Group allowed
-     * Check if group is allowed to do specified action, admin always allowed
-     * @param int $perm_par Permission id or name to check
-     * @param int|string|bool $group_par Group id or name to check, or if false checks all user groups
-     * @return bool
-     */
-    public function is_group_allowed($perm_par, $group_par=false){
-
-        $perm_id = $this->get_perm_id($perm_par);
-
-        // if group par is given
-        if($group_par != false){
-
-            $group_par = $this->get_group_id($group_par);
-
-            $query = $this->CI->db->where('perm_id', $perm_id);
-            $query = $this->CI->db->where('group_id', $group_par);
-            $query = $this->CI->db->get( $this->config_vars['perm_to_group'] );
-
-            if( $query->num_rows() > 0){
-                return true;
-            } else {
-                return false;
-            }
-        }
-        // if group par is not given
-        // checks current user's all groups
-        else {
-            // if public is allowed or he is admin
-            if ( $this->is_admin( $this->CI->session->userdata('id')) or
-                $this->is_group_allowed($perm_id, $this->config_vars['public_group']) )
-            {return true;}
-
-            // if is not login
-            if (!$this->is_loggedin()){return false;}
-
-            $group_pars = $this->get_user_groups();
-
-            foreach ($group_pars as $g ){
-                if($this->is_group_allowed($perm_id, $g -> id)){
-                    return true;
-                }
-            }
-            return false;
-        }
-    }
-
-    //tested
-    /**
-     * Allow User
-     * Add User to permission
-     * @param int $user_id User id to deny
-     * @param int $perm_par Permission id or name to allow
-     * @return bool Allow success/failure
-     */
-    public function allow_user($user_id, $perm_par) {
-
-        $perm_id = $this->get_perm_id($perm_par);
-
-        $query = $this->CI->db->where('user_id',$user_id);
-        $query = $this->CI->db->where('perm_id',$perm_id);
-        $query = $this->CI->db->get($this->config_vars['perm_to_user']);
-
-        // if not inserted before
-        if ($query->num_rows() < 1) {
-
-            $data = array(
-                'user_id' => $user_id,
-                'perm_id' => $perm_id
-            );
-
-            return $this->CI->db->insert($this->config_vars['perm_to_user'], $data);
-        }
-        return true;
-    }
-
-    //tested
-    /**
-     * Deny User
-     * Remove user from permission
-     * @param int $user_id User id to deny
-     * @param int $perm_par Permission id or name to deny
-     * @return bool Deny success/failure
-     */
-    public function deny_user($user_id, $perm_par) {
-
-        $perm_id = $this->get_perm_id($perm_par);
-
-        $this->CI->db->where('user_id', $user_id);
-        $this->CI->db->where('perm_id', $perm_id);
-
-        return $this->CI->db->delete($this->config_vars['perm_to_user']);
-    }
-
-    //tested
-    /**
-     * Allow Group
-     * Add group to permission
-     * @param int|string|bool $group_par Group id or name to allow
-     * @param int $perm_par Permission id or name to allow
-     * @return bool Allow success/failure
-     */
-    public function allow_group($group_par, $perm_par) {
-
-        $perm_id = $this->get_perm_id($perm_par);
-        $group_id = $this->get_group_id($group_par);
-
-        $query = $this->CI->db->where('group_id',$group_id);
-        $query = $this->CI->db->where('perm_id',$perm_id);
-        $query = $this->CI->db->get($this->config_vars['perm_to_group']);
-
-        if ($query->num_rows() < 1) {
-
-            $data = array(
-                'group_id' => $group_id,
-                'perm_id' => $perm_id
-            );
-
-            return $this->CI->db->insert($this->config_vars['perm_to_group'], $data);
-        }
-
-        return true;
-    }
-
-    //tested
-    /**
-     * Deny Group
-     * Remove group from permission
-     * @param int|string|bool $group_par Group id or name to deny
-     * @param int $perm_par Permission id or name to deny
-     * @return bool Deny success/failure
-     */
-    public function deny_group($group_par, $perm_par) {
-
-        $perm_id = $this->get_perm_id($perm_par);
-        $group_id = $this->get_group_id($group_par);
-
-        $this->CI->db->where('group_id', $group_id);
-        $this->CI->db->where('perm_id', $perm_id);
-
-        return $this->CI->db->delete($this->config_vars['perm_to_group']);
-    }
-
-    //tested
-    /**
-     * List Permissions
-     * List all permissions
-     * @return object Array of permissions
-     */
-    public function list_perms() {
-
-        $query = $this->CI->db->get($this->config_vars['perms']);
-        return $query->result();
-    }
-
-    //tested
-    /**
-     * Get permission id
-     * Get permission id from permisison name or id
-     * @param int|string $perm_par Permission id or name to get
-     * @return int Permission id or NULL if perm does not exist
-     */
-    public function get_perm_id($perm_par) {
-
-        if( is_numeric($perm_par) ) { return $perm_par; }
-
-        $query = $this->CI->db->where('name', $perm_par);
-        $query = $this->CI->db->get($this->config_vars['perms']);
-
-        if ($query->num_rows() == 0)
-            return NULL;
-
-        $row = $query->row();
-        return $row->id;
-    }
-
-    ########################
-    # Private Message Functions
-    ########################
-
-    //tested
-    /**
-     * Send Private Message
-     * Send a private message to another user
-     * @param int $sender_id User id of private message sender
-     * @param int $receiver_id User id of private message receiver
-     * @param string $title Message title/subject
-     * @param string $message Message body/content
-     * @return bool Send successful/failed
-     */
-    public function send_pm( $sender_id, $receiver_id, $title, $message ){
-
-        if ( !is_numeric($receiver_id) or $sender_id == $receiver_id ){
-            $this->error($this->CI->lang->line('self_pm'));
-            return false;
-        }
-
-        $query = $this->CI->db->where('id', $receiver_id);
-        $query = $this->CI->db->where('banned', 0);
-
-        $query = $this->CI->db->get( $this->config_vars['users'] );
-
-        // if user not exist or banned
-        if ( $query->num_rows() < 1 ){
-            $this->error($this->CI->lang->line('no_user'));
-            return false;
-        }
-
-        $query = $this->CI->db->where('id', $sender_id);
-        $query = $this->CI->db->where('banned', 0);
-
-        $query = $this->CI->db->get( $this->config_vars['users'] );
-
-        // if user not exist or banned
-        if ( $query->num_rows() < 1 ){
-            $this->error($this->CI->lang->line('no_user'));
-            return false;
-        }
-
-
-        $data = array(
-            'sender_id' => $sender_id,
-            'receiver_id' => $receiver_id,
-            'title' => $title,
-            'message' => $message,
-            'date' => date('Y-m-d H:i:s')
-        );
-
-        return $query = $this->CI->db->insert( $this->config_vars['pms'], $data );
-    }
-
-    //tested
-    /**
-     * List Private Messages
-     * If receiver id not given retruns current user's pms, if sender_id given, it returns only pms from given sender
-     * @param int $limit Number of private messages to be returned
-     * @param int $offset Offset for private messages to be returned (for pagination)
-     * @param int $sender_id User id of private message sender
-     * @param int $receiver_id User id of private message receiver
-     * @return object Array of private messages
-     */
-    public function list_pms($limit=5, $offset=0, $receiver_id = false, $sender_id=false){
-
-        $query='';
-
-        if ( $receiver_id != false){
-            $query = $this->CI->db->where('receiver_id', $receiver_id);
-        }
-
-        if( $sender_id != false ){
-            $query = $this->CI->db->where('sender_id', $sender_id);
-        }
-
-        $query = $this->CI->db->order_by('id','DESC');
-        $query = $this->CI->db->get( $this->config_vars['pms'], $limit, $offset);
-        return $query->result();
-    }
-
-    //tested
-    /**
-     * Get Private Message
-     * Get private message by id
-     * @param int $pm_id Private message id to be returned
-     * @param bool $set_as_read Whether or not to mark message as read
-     * @return object Private message
-     */
-    public function get_pm($pm_id, $set_as_read = true){
-
-        $query = $this->CI->db->where('id', $pm_id);
-        $query = $this->CI->db->get( $this->config_vars['pms'] );
-
-        if ($query->num_rows() < 1) {
-            $this->error( $this->CI->lang->line('no_pm') );
-        }
-
-        if ($set_as_read) $this->set_as_read_pm($pm_id);
-
-        return $query->result();
-    }
-
-    //tested
-    /**
-     * Delete Private Message
-     * Delete private message by id
-     * @param int $pm_id Private message id to be deleted
-     * @return bool Delete success/failure
-     */
-    public function delete_pm($pm_id){
-        
-        return $this->CI->db->delete( $this->config_vars['pms'], array('id' => $pm_id) );
-    }
-
-    //tested
-    /**
-     * Count unread Private Message
-     * Count number of unread private messages
-     * @param int|bool $receiver_id User id for message receiver, if false returns for current user
-     * @return int Number of unread messages
-     */
-    public function count_unread_pms($receiver_id=false){
-
-        if(!$receiver_id){
-            $receiver_id = $this->CI->session->userdata('id');
-        }
-
-        $query = $this->CI->db->where('receiver_id', $receiver_id);
-        $query = $this->CI->db->where('read', 0);
-        $query = $this->CI->db->get( $this->config_vars['pms'] );
-
-        return $query->num_rows();
-    }
-
-    //tested
-    /**
-     * Set Private Message as read
-     * Set private message as read
-     * @param int $pm_id Private message id to mark as read
-     */
-    public function set_as_read_pm($pm_id){
-
-        $data = array(
-            'read' => 1,
-        );
-
-        $this->CI->db->update( $this->config_vars['pms'], $data, "id = $pm_id");
-    }
-
-    ########################
-    # Error / Info Functions
-    ########################
-
-    /**
-     * Error
-     * Add message to error array and set flash data
-     * @param string $message Message to add to array
-     * @param boolean $flashdata if true add $message to CI flashdata (deflault: false)
-     */
-    public function error($message = '', $flashdata = false){
-        $this->errors[] = $message;
-        if($flashdata) {
+	//tested
+	/**
+	 * Update last login
+	 * Update user's last login date
+	 * @param int|bool $user_id User id to update or false for current user
+	 * @return bool Update fails/succeeds
+	 */
+	public function update_last_login($user_id = FALSE) {
+
+		if ($user_id == FALSE)
+			$user_id = $this->CI->session->userdata('id');
+
+		$data['last_login'] = date("Y-m-d H:i:s");
+		$data['ip_address'] = $this->CI->input->ip_address();
+
+		$this->CI->db->where('id', $user_id);
+		return $this->CI->db->update($this->config_vars['users'], $data);
+	}
+
+
+	//tested
+	/**
+	 * Update login attempt and if exceeds return false
+	 * Update user's last login attemp date and number date
+	 * @param string $email User email
+	 * @return bool
+	 */
+	public function update_login_attempts($email) {
+
+		$user_id = $this->get_user_id($email);
+
+		$query = $this->CI->db->where('id', $user_id);
+		$query = $this->CI->db->get( $this->config_vars['users'] );
+		$row = $query->row();
+
+
+		$data = array();
+
+		if ( strtotime($row->last_login_attempt) == strtotime(date("Y-m-d H:0:0"))) {
+			$data['login_attempts'] = $row->login_attempts + 1;
+
+			$query = $this->CI->db->where('id', $user_id);
+			$this->CI->db->update($this->config_vars['users'], $data);
+
+		} else {
+
+			$data['last_login_attempt'] = date("Y-m-d H:0:0");
+			$data['login_attempts'] = 1;
+
+			$this->CI->db->where('id', $user_id);
+			$this->CI->db->update($this->config_vars['users'], $data);
+
+		}
+
+		if ( $data['login_attempts'] > $this->config_vars['max_login_attempt'] ) {
+			return false;
+		} else {
+			return true;
+		}
+
+	}
+
+	/**
+	 * Update remember
+	 * Update amount of time a user is remembered for
+	 * @param int $user_id User id to update 
+	 * @param int $expression
+	 * @param int $expire 
+	 * @return bool Update fails/succeeds
+	 */
+	public function update_remember($user_id, $expression=null, $expire=null) {
+
+		$data['remember_time'] = $expire;
+		$data['remember_exp'] = $expression;
+
+		$query = $this->CI->db->where('id',$user_id);
+		return $this->CI->db->update($this->config_vars['users'], $data);
+	}
+
+
+	########################
+	# User Functions
+	########################
+
+	//tested
+	/**
+	 * Create user
+	 * Creates a new user
+	 * @param string $email User's email address
+	 * @param string $pass User's password
+	 * @param string $name User's name
+	 * @return int|bool False if create fails or returns user id if successful
+	 */
+	public function create_user($email, $pass, $name) {
+
+		$valid = true;
+
+		// if email is already exist
+		if ($this->user_exsist_by_email($email)) {
+			$this->error($this->CI->lang->line('aauth_error_email_exists'));
+			$valid = false;
+		}
+		if ($this->user_exsist_by_name($name)) {
+			$this->error($this->CI->lang->line('aauth_error_username_exists'));
+			$valid = false;
+		}
+
+		if ( ! valid_email($email)){
+			$this->error($this->CI->lang->line('aauth_error_email_invalid'));
+			$valid = false;
+		}
+		if ( strlen($pass) < 5 or strlen($pass) > $this->config_vars['max'] ){
+			$this->error($this->CI->lang->line('aauth_error_password_invalid'));
+			$valid = false;
+		}
+		if ($name !='' and !ctype_alnum(str_replace($this->config_vars['valid_chars'], '', $name))){
+			$this->error($this->CI->lang->line('aauth_error_username_invalid'));
+			$valid = false;
+		}
+		if (empty($name)){
+			$this->error($this->CI->lang->line('aauth_error_username_required'));
+			$valid = false;
+		}
+
+		if (!$valid) {
+			return false; }
+
+		$data = array(
+			'email' => $email,
+			'pass' => $this->hash_password($pass, 0), // Password cannot be blank but user_id required for salt, setting bad password for now
+			'name' => $name,
+		);
+
+		if ( $this->CI->db->insert($this->config_vars['users'], $data )){
+
+			$user_id = $this->CI->db->insert_id();
+
+			// set default group
+			$this->add_member($user_id, $this->config_vars['default_group']);
+
+			// if verification activated
+			if($this->config_vars['verification']){
+				$data = null;
+				$data['banned'] = 1;
+
+				$this->CI->db->where('id', $user_id);
+				$this->CI->db->update($this->config_vars['users'], $data);
+
+				// sends verifition ( !! e-mail settings must be set)
+				$this->send_verification($user_id);
+			}
+
+			// Update to correct salted password
+			$data = null;
+			$data['pass'] = $this->hash_password($pass, $user_id);
+			$this->CI->db->where('id', $user_id);
+			$this->CI->db->update($this->config_vars['users'], $data);
+
+			return $user_id;
+
+		} else {
+			return FALSE;
+		}
+	}
+
+	//tested
+	/**
+	 * Update user
+	 * Updates existing user details
+	 * @param int $user_id User id to update
+	 * @param string|bool $email User's email address, or false if not to be updated
+	 * @param string|bool $pass User's password, or false if not to be updated
+	 * @param string|bool $name User's name, or false if not to be updated
+	 * @return bool Update fails/succeeds
+	 */
+	public function update_user($user_id, $email = FALSE, $pass = FALSE, $name = FALSE) {
+
+		$data = array();
+
+		if ($email != FALSE) {
+			$data['email'] = $email;
+		}
+
+		if ($pass != FALSE) {
+			$data['pass'] = $this->hash_password($pass, $user_id);
+		}
+
+		if ($name != FALSE) {
+			$data['name'] = $name;
+		}
+
+		$this->CI->db->where('id', $user_id);
+		return $this->CI->db->update($this->config_vars['users'], $data);
+	}
+
+	//tested
+	/**
+	 * List users
+	 * Return users as an object array
+	 * @param bool|int $group_par Specify group id to list group or false for all users
+	 * @param string $limit Limit of users to be returned
+	 * @param bool $offset Offset for limited number of users
+	 * @param bool $include_banneds Include banned users
+	 * @return array Array of users
+	 */
+	public function list_users($group_par = FALSE, $limit = FALSE, $offset = FALSE, $include_banneds = FALSE) {
+
+		// if group_par is given
+		if ($group_par != FALSE) {
+
+			$group_par = $this->get_group_id($group_par);
+			$this->CI->db->select('*')
+				->from($this->config_vars['users'])
+				->join($this->config_vars['user_to_group'], $this->config_vars['users'] . ".id = " . $this->config_vars['user_to_group'] . ".user_id")
+				->where($this->config_vars['user_to_group'] . ".group_id", $group_par);
+
+			// if group_par is not given, lists all users
+		} else {
+
+			$this->CI->db->select('*')
+				->from($this->config_vars['users']);
+		}
+
+		// banneds
+		if (!$include_banneds) {
+			$this->CI->db->where('banned != ', 1);
+		}
+
+		// limit
+		if ($limit) {
+
+			if ($offset == FALSE)
+				$this->CI->db->limit($limit);
+			else
+				$this->CI->db->limit($limit, $offset);
+		}
+
+		$query = $this->CI->db->get();
+
+		return $query->result();
+	}
+
+	//tested
+	/**
+	 * Get user
+	 * Get user information
+	 * @param int|bool $user_id User id to get or false for current user
+	 * @return object User information
+	 */
+	public function get_user($user_id = FALSE) {
+
+		if ($user_id == FALSE)
+			$user_id = $this->CI->session->userdata('id');
+
+		$query = $this->CI->db->where('id', $user_id);
+		$query = $this->CI->db->get($this->config_vars['users']);
+
+		if ($query->num_rows() <= 0){
+			$this->error($this->CI->lang->line('aauth_error_no_user'));
+			return FALSE;
+		}
+		return $query->row();
+	}
+
+	/**
+	 * Verify user
+	 * Activates user account based on verification code
+	 * @param int $user_id User id to activate
+	 * @param string $ver_code Code to validate against
+	 * @return bool Activation fails/succeeds
+	 */
+	public function verify_user($user_id, $ver_code){
+
+		$query = $this->CI->db->where('id', $user_id);
+		$query = $this->CI->db->where('verification_code', $ver_code);
+		$query = $this->CI->db->get( $this->config_vars['users'] );
+
+		// if ver code is true
+		if( $query->num_rows() > 0 ){
+
+			$data =	 array(
+				'verification_code' => '',
+				'banned' => 0
+			);
+
+			$this->CI->db->where('id', $user_id);
+			$this->CI->db->update($this->config_vars['users'] , $data);
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Send verification email
+	 * Sends a verification email based on user id
+	 * @param int $user_id User id to send verification email to
+	 * @todo return success indicator
+	 */
+	public function send_verification($user_id){
+
+		$query = $this->CI->db->where( 'id', $user_id );
+		$query = $this->CI->db->get( $this->config_vars['users'] );
+
+		if ($query->num_rows() > 0){
+			$row = $query->row();
+
+			$ver_code = random_string('alnum', 16);
+
+			$data['verification_code'] = $ver_code;
+
+			$this->CI->db->where('id', $user_id);
+			$this->CI->db->update($this->config_vars['users'], $data);
+
+			$this->CI->email->from( $this->config_vars['email'], $this->config_vars['name']);
+			$this->CI->email->to($row->email);
+			$this->CI->email->subject($this->CI->lang->line('aauth_email_verification_subject'));
+			$this->CI->email->message($this->CI->lang->line('aauth_email_verification_code') . $ver_code .
+				$this->CI->lang->line('aauth_email_verification_link') . $user_id . '/' . $ver_code );
+			$this->CI->email->send();
+		}
+	}
+
+	//not tested excatly
+	/**
+	 * Delete user
+	 * Delete a user from database. WARNING Can't be undone
+	 * @param int $user_id User id to delete
+	 */
+	public function delete_user($user_id) {
+
+		$this->CI->db->where('id', $user_id);
+		$this->CI->db->delete($this->config_vars['users']);
+
+		// delete from perm_to_user
+		$this->CI->db->where('user_id', $user_id);
+		$this->CI->db->delete($this->config_vars['perm_to_user']);
+
+		// delete from user_to_group
+		$this->CI->db->where('user_id', $user_id);
+		$this->CI->db->delete($this->config_vars['user_to_group']);
+
+		// delete user vars
+		$this->CI->db->where('user_id', $user_id);
+		$this->CI->db->delete($this->config_vars['user_variables']);
+	}
+
+	//tested
+	/**
+	 * Ban user
+	 * Bans a user account
+	 * @param int $user_id User id to ban
+	 * @return bool Ban fails/succeeds
+	 */
+	public function ban_user($user_id) {
+
+		$data = array(
+			'banned' => 1,
+			'verification_code' => ''
+		);
+
+		$this->CI->db->where('id', $user_id);
+
+		return $this->CI->db->update($this->config_vars['users'], $data);
+	}
+
+	//tested
+	/**
+	 * Unban user
+	 * Activates user account
+	 * Same with unlock_user()
+	 * @param int $user_id User id to activate
+	 * @return bool Activation fails/succeeds
+	 */
+	public function unban_user($user_id) {
+
+		$data = array(
+			'banned' => 0
+		);
+
+		$this->CI->db->where('id', $user_id);
+
+		return $this->CI->db->update($this->config_vars['users'], $data);
+	}
+
+	//tested
+	/**
+	 * Check user banned
+	 * Checks if a user is banned
+	 * @param int $user_id User id to check
+	 * @return bool False if banned, True if not
+	 */
+	public function is_banned($user_id) {
+
+		$query = $this->CI->db->where('id', $user_id);
+		$query = $this->CI->db->where('banned', 1);
+
+		$query = $this->CI->db->get($this->config_vars['users']);
+
+		if ($query->num_rows() > 0)
+			return TRUE;
+		else
+			return FALSE;
+	}
+
+	/**
+	 * user_exsist_by_id
+	 * Check if user exist by user id
+	 * @param $user_id
+	 *
+	 * @return bool
+	 */
+	public function user_exsist_by_id( $user_id ) {
+		$query = $this->CI->db->where('id', $user_id);
+
+		$query = $this->CI->db->get($this->config_vars['users']);
+
+		if ($query->num_rows() > 0)
+			return TRUE;
+		else
+			return FALSE;
+	}
+
+	/**
+	 * user_exsist_by_name
+	 * Check if user exist by name
+	 * @param $user_id
+	 *
+	 * @return bool
+	 */
+	public function user_exsist_by_name( $name ) {
+		$query = $this->CI->db->where('name', $name);
+
+		$query = $this->CI->db->get($this->config_vars['users']);
+
+		if ($query->num_rows() > 0)
+			return TRUE;
+		else
+			return FALSE;
+	}
+
+	/**
+	 * user_exsist_by_email
+	 * Check if user exsist by user email
+	 * @param $user_email
+	 *
+	 * @return bool
+	 */
+	public function user_exsist_by_email( $user_email ) {
+		$query = $this->CI->db->where('email', $user_email);
+
+		$query = $this->CI->db->get($this->config_vars['users']);
+
+		if ($query->num_rows() > 0)
+			return TRUE;
+		else
+			return FALSE;
+	}
+
+	/**
+	 * Get user id
+	 * Get user id from email address, if par. not given, return current user's id
+	 * @param string|bool $email Email address for user
+	 * @return int User id
+	 */
+	public function get_user_id($email=false) {
+
+		if( ! $email){
+			$query = $this->CI->db->where('id', $this->CI->session->userdata('id'));
+		} else {
+			$query = $this->CI->db->where('email', $email);
+		}
+
+		$query = $this->CI->db->get($this->config_vars['users']);
+
+		if ($query->num_rows() <= 0){
+			$this->error($this->CI->lang->line('aauth_error_no_user'));
+			return FALSE;
+		}
+		return $query->row()->id;
+	}
+
+	/**
+	 * Get user groups
+	 * Get groups a user is in
+	 * @param int|bool $user_id User id to get or false for current user
+	 * @return array Groups
+	 */
+	public function get_user_groups($user_id = false){
+
+		if ($user_id==false) { $user_id = $this->CI->session->userdata('id'); }
+
+		$this->CI->db->select('*');
+		$this->CI->db->from($this->config_vars['user_to_group']);
+		$this->CI->db->join($this->config_vars['groups'], "id = group_id");
+		$this->CI->db->where('user_id', $user_id);
+
+		return $query = $this->CI->db->get()->result();
+	}
+
+	//tested
+	/**
+	 * Update activity
+	 * Update user's last activity date
+	 * @param int|bool $user_id User id to update or false for current user
+	 * @return bool Update fails/succeeds
+	 */
+	public function update_activity($user_id = FALSE) {
+
+		if ($user_id == FALSE)
+			$user_id = $this->CI->session->userdata('id');
+
+		if($user_id==false){return false;}
+
+		$data['last_activity'] = date("Y-m-d H:i:s");
+
+		$query = $this->CI->db->where('id',$user_id);
+		return $this->CI->db->update($this->config_vars['users'], $data);
+	}
+
+	//tested
+	/**
+	 * Hash password
+	 * Hash the password for storage in the database
+	 * (thanks to Jacob Tomlinson for contribution)
+	 * @param string $pass Password to hash
+	 * @param $userid
+	 * @return string Hashed password
+	 */
+	function hash_password($pass, $userid) {
+
+		$salt = md5($userid);
+		return hash('sha256', $salt.$pass);
+	}
+
+	########################
+	# Group Functions
+	########################
+
+	//tested
+	/**
+	 * Create group
+	 * Creates a new group
+	 * @param string $group_name New group name
+	 * @return int|bool Group id or false on fail
+	 */
+	public function create_group($group_name) {
+
+		$query = $this->CI->db->get_where($this->config_vars['groups'], array('name' => $group_name));
+
+		if ($query->num_rows() < 1) {
+
+			$data = array(
+				'name' => $group_name
+			);
+			$this->CI->db->insert($this->config_vars['groups'], $data);
+			return $this->CI->db->insert_id();
+		}
+
+		$this->info($this->CI->lang->line('aauth_info_group_exists'));
+		return FALSE;
+	}
+
+	//tested
+	/**
+	 * Update group
+	 * Change a groups name
+	 * @param int $group_id Group id to update
+	 * @param string $group_name New group name
+	 * @return bool Update success/failure
+	 */
+	public function update_group($group_par, $group_name) {
+
+		$group_id = $this->get_group_id($group_par);
+
+		$data['name'] = $group_name;
+
+		$this->CI->db->where('id', $group_id);
+		return $this->CI->db->update($this->config_vars['groups'], $data);
+	}
+
+	//tested
+	/**
+	 * Delete group
+	 * Delete a group from database. WARNING Can't be undone
+	 * @param int $group_id User id to delete
+	 * @return bool Delete success/failure
+	 */
+	public function delete_group($group_par) {
+
+		$group_id = $this->get_group_id($group_par);
+		
+	$this->CI->db->where('id',$group_id);
+	$query = $this->CI->db->get($this->config_vars['groups']);
+	if ($query->num_rows() == 0){
+		return false;
+	}
+
+		// bug fixed
+		// now users are deleted from user_to_group table
+		$this->CI->db->where('group_id', $group_id);
+		$this->CI->db->delete($this->config_vars['user_to_group']);
+
+		$this->CI->db->where('id', $group_id);
+		return $this->CI->db->delete($this->config_vars['groups']);
+	}
+
+	//tested
+	/**
+	 * Add member
+	 * Add a user to a group
+	 * @param int $user_id User id to add to group
+	 * @param int|string $group_par Group id or name to add user to
+	 * @return bool Add success/failure
+	 */
+	public function add_member($user_id, $group_par) {
+
+		$group_id = $this->get_group_id($group_par);
+
+		if( ! $group_id ) {
+
+			$this->error( $this->CI->lang->line('aauth_error_no_group') );
+			return false;
+		}
+
+		$query = $this->CI->db->where('user_id',$user_id);
+		$query = $this->CI->db->where('group_id',$group_id);
+		$query = $this->CI->db->get($this->config_vars['user_to_group']);
+
+		if ($query->num_rows() < 1) {
+			$data = array(
+				'user_id' => $user_id,
+				'group_id' => $group_id
+			);
+
+			return $this->CI->db->insert($this->config_vars['user_to_group'], $data);
+		}
+		$this->info($this->CI->lang->line('aauth_info_already_member'));
+		return true;
+	}
+
+	//tested
+	/**
+	 * Remove member
+	 * Remove a user from a group
+	 * @param int $user_id User id to remove from group
+	 * @param int|string $group_par Group id or name to remove user from
+	 * @return bool Remove success/failure
+	 */
+	public function remove_member($user_id, $group_par) {
+
+		$group_par = $this->get_group_id($group_par);
+		$this->CI->db->where('user_id', $user_id);
+		$this->CI->db->where('group_id', $group_par);
+		return $this->CI->db->delete($this->config_vars['user_to_group']);
+	}
+
+	//tested
+	/**
+	 * Is member
+	 * Check if current user is a member of a group
+	 * @param int|string $group_par Group id or name to check
+	 * @param int|bool $user_id User id, if not given current user
+	 * @return bool
+	 */
+	public function is_member( $group_par, $user_id = false ) {
+
+		// if user_id false (not given), current user
+		if( ! $user_id){
+			$user_id = $this->CI->session->userdata('id');
+		}
+
+		$group_id = $this->get_group_id($group_par);
+
+		$query = $this->CI->db->where('user_id', $user_id);
+		$query = $this->CI->db->where('group_id', $group_id);
+		$query = $this->CI->db->get($this->config_vars['user_to_group']);
+
+		$row = $query->row();
+
+		if ($query->num_rows() > 0) {
+			return TRUE;
+		} else {
+			return FALSE;
+		}
+	}
+
+	//tested
+	/**
+	 * Is admin
+	 * Check if current user is a member of the admin group
+	 * @param int $user_id User id to check, if it is not given checks current user
+	 * @return bool
+	 */
+	public function is_admin( $user_id = false ) {
+
+		return $this->is_member($this->config_vars['admin_group'], $user_id);
+	}
+
+	//tested
+	/**
+	 * List groups
+	 * List all groups
+	 * @return object Array of groups
+	 */
+	public function list_groups() {
+
+		$query = $this->CI->db->get($this->config_vars['groups']);
+		return $query->result();
+	}
+
+
+	//tested
+	/**
+	 * Get group name
+	 * Get group name from group id
+	 * @param int $group_id Group id to get
+	 * @return string Group name
+	 */
+	public function get_group_name($group_id) {
+
+		$query = $this->CI->db->where('id', $group_id);
+		$query = $this->CI->db->get($this->config_vars['groups']);
+
+		if ($query->num_rows() == 0)
+			return FALSE;
+
+		$row = $query->row();
+		return $row->name;
+	}
+
+	//tested
+	/**
+	 * Get group id
+	 * Get group id from group name or id ( ! Case sensitive)
+	 * @param int|string $group_par Group id or name to get
+	 * @return int Group id
+	 */
+	public function get_group_id ( $group_par ) {
+
+		if( is_numeric($group_par) ) { return $group_par; }
+
+		$query = $this->CI->db->where('name', $group_par);
+		$query = $this->CI->db->get($this->config_vars['groups']);
+
+		if ($query->num_rows() == 0)
+			return FALSE;
+
+		$row = $query->row();
+		return $row->id;
+	}
+
+	########################
+	# Permission Functions
+	########################
+
+	//tested
+	/**
+	 * Create permission
+	 * Creates a new permission type
+	 * @param string $perm_name New permission name
+	 * @param string $definition Permission description
+	 * @return int|bool Permission id or false on fail
+	 */
+	public function create_perm($perm_name, $definition='') {
+
+		$query = $this->CI->db->get_where($this->config_vars['perms'], array('name' => $perm_name));
+
+		if ($query->num_rows() < 1) {
+
+			$data = array(
+				'name' => $perm_name,
+				'definition'=> $definition
+			);
+			$this->CI->db->insert($this->config_vars['perms'], $data);
+			return $this->CI->db->insert_id();
+		}
+		$this->info($this->CI->lang->line('aauth_info_perm_exists'));
+		return FALSE;
+	}
+
+	//tested
+	/**
+	 * Update permission
+	 * Updates permission name and description
+	 * @param int|string $perm_par Permission id or permission name
+	 * @param string $perm_name New permission name
+	 * @param string $definition Permission description
+	 * @return bool Update success/failure
+	 */
+	public function update_perm($perm_par, $perm_name=false, $definition=false) {
+
+		$perm_id = $this->get_perm_id($perm_par);
+
+		if ($perm_name != false)
+			$data['name'] = $perm_name;
+
+		if ($definition != false)
+			$data['definition'] = $definition;
+
+		$this->CI->db->where('id', $perm_id);
+		return $this->CI->db->update($this->config_vars['perms'], $data);
+	}
+
+	//not ok
+	/**
+	 * Delete permission
+	 * Delete a permission from database. WARNING Can't be undone
+	 * @param int|string $perm_par Permission id or perm name to delete
+	 * @return bool Delete success/failure
+	 */
+	public function delete_perm($perm_par) {
+
+		$perm_id = $this->get_perm_id($perm_par);
+
+		// deletes from perm_to_gropup table
+		$this->CI->db->where('perm_id', $perm_id);
+		$this->CI->db->delete($this->config_vars['perm_to_group']);
+
+		// deletes from perm_to_user table
+		$this->CI->db->where('perm_id', $perm_id);
+		$this->CI->db->delete($this->config_vars['perm_to_group']);
+
+		// deletes from permission table
+		$this->CI->db->where('id', $perm_id);
+		return $this->CI->db->delete($this->config_vars['perms']);
+	}
+
+	/**
+	 * Is user allowed
+	 * Check if user allowed to do specified action, admin always allowed
+	 * first checks user permissions then check group permissions
+	 * @param int $perm_par Permission id or name to check
+	 * @param int|bool $user_id User id to check, or if false checks current user
+	 * @return bool
+	 */
+	public function is_allowed($perm_par, $user_id=false){
+
+		$perm_id = $this->get_perm_id($perm_par);
+
+		if( $user_id == false){
+			$user_id = $this->CI->session->userdata('id');
+		}
+
+		$query = $this->CI->db->where('perm_id', $perm_id);
+		$query = $this->CI->db->where('user_id', $user_id);
+		$query = $this->CI->db->get( $this->config_vars['perm_to_user'] );
+
+		if( $query->num_rows() > 0){
+			return true;
+		} elseif ($this->is_group_allowed($perm_id)) {
+			return true;
+		} else {
+			return false;
+		}
+
+	}
+
+	/**
+	 * Is Group allowed
+	 * Check if group is allowed to do specified action, admin always allowed
+	 * @param int $perm_par Permission id or name to check
+	 * @param int|string|bool $group_par Group id or name to check, or if false checks all user groups
+	 * @return bool
+	 */
+	public function is_group_allowed($perm_par, $group_par=false){
+
+		$perm_id = $this->get_perm_id($perm_par);
+
+		// if group par is given
+		if($group_par != false){
+
+			$group_par = $this->get_group_id($group_par);
+
+			$query = $this->CI->db->where('perm_id', $perm_id);
+			$query = $this->CI->db->where('group_id', $group_par);
+			$query = $this->CI->db->get( $this->config_vars['perm_to_group'] );
+
+			if( $query->num_rows() > 0){
+				return true;
+			} else {
+				return false;
+			}
+		}
+		// if group par is not given
+		// checks current user's all groups
+		else {
+			// if public is allowed or he is admin
+			if ( $this->is_admin( $this->CI->session->userdata('id')) or
+				$this->is_group_allowed($perm_id, $this->config_vars['public_group']) )
+			{return true;}
+
+			// if is not login
+			if (!$this->is_loggedin()){return false;}
+
+			$group_pars = $this->get_user_groups();
+
+			foreach ($group_pars as $g ){
+				if($this->is_group_allowed($perm_id, $g -> id)){
+					return true;
+				}
+			}
+			return false;
+		}
+	}
+
+	//tested
+	/**
+	 * Allow User
+	 * Add User to permission
+	 * @param int $user_id User id to deny
+	 * @param int $perm_par Permission id or name to allow
+	 * @return bool Allow success/failure
+	 */
+	public function allow_user($user_id, $perm_par) {
+
+		$perm_id = $this->get_perm_id($perm_par);
+
+		$query = $this->CI->db->where('user_id',$user_id);
+		$query = $this->CI->db->where('perm_id',$perm_id);
+		$query = $this->CI->db->get($this->config_vars['perm_to_user']);
+
+		// if not inserted before
+		if ($query->num_rows() < 1) {
+
+			$data = array(
+				'user_id' => $user_id,
+				'perm_id' => $perm_id
+			);
+
+			return $this->CI->db->insert($this->config_vars['perm_to_user'], $data);
+		}
+		return true;
+	}
+
+	//tested
+	/**
+	 * Deny User
+	 * Remove user from permission
+	 * @param int $user_id User id to deny
+	 * @param int $perm_par Permission id or name to deny
+	 * @return bool Deny success/failure
+	 */
+	public function deny_user($user_id, $perm_par) {
+
+		$perm_id = $this->get_perm_id($perm_par);
+
+		$this->CI->db->where('user_id', $user_id);
+		$this->CI->db->where('perm_id', $perm_id);
+
+		return $this->CI->db->delete($this->config_vars['perm_to_user']);
+	}
+
+	//tested
+	/**
+	 * Allow Group
+	 * Add group to permission
+	 * @param int|string|bool $group_par Group id or name to allow
+	 * @param int $perm_par Permission id or name to allow
+	 * @return bool Allow success/failure
+	 */
+	public function allow_group($group_par, $perm_par) {
+
+		$perm_id = $this->get_perm_id($perm_par);
+		$group_id = $this->get_group_id($group_par);
+
+		$query = $this->CI->db->where('group_id',$group_id);
+		$query = $this->CI->db->where('perm_id',$perm_id);
+		$query = $this->CI->db->get($this->config_vars['perm_to_group']);
+
+		if ($query->num_rows() < 1) {
+
+			$data = array(
+				'group_id' => $group_id,
+				'perm_id' => $perm_id
+			);
+
+			return $this->CI->db->insert($this->config_vars['perm_to_group'], $data);
+		}
+
+		return true;
+	}
+
+	//tested
+	/**
+	 * Deny Group
+	 * Remove group from permission
+	 * @param int|string|bool $group_par Group id or name to deny
+	 * @param int $perm_par Permission id or name to deny
+	 * @return bool Deny success/failure
+	 */
+	public function deny_group($group_par, $perm_par) {
+
+		$perm_id = $this->get_perm_id($perm_par);
+		$group_id = $this->get_group_id($group_par);
+
+		$this->CI->db->where('group_id', $group_id);
+		$this->CI->db->where('perm_id', $perm_id);
+
+		return $this->CI->db->delete($this->config_vars['perm_to_group']);
+	}
+
+	//tested
+	/**
+	 * List Permissions
+	 * List all permissions
+	 * @return object Array of permissions
+	 */
+	public function list_perms() {
+
+		$query = $this->CI->db->get($this->config_vars['perms']);
+		return $query->result();
+	}
+
+	//tested
+	/**
+	 * Get permission id
+	 * Get permission id from permisison name or id
+	 * @param int|string $perm_par Permission id or name to get
+	 * @return int Permission id or NULL if perm does not exist
+	 */
+	public function get_perm_id($perm_par) {
+
+		if( is_numeric($perm_par) ) { return $perm_par; }
+
+		$query = $this->CI->db->where('name', $perm_par);
+		$query = $this->CI->db->get($this->config_vars['perms']);
+
+		if ($query->num_rows() == 0)
+			return NULL;
+
+		$row = $query->row();
+		return $row->id;
+	}
+
+	########################
+	# Private Message Functions
+	########################
+
+	//tested
+	/**
+	 * Send Private Message
+	 * Send a private message to another user
+	 * @param int $sender_id User id of private message sender
+	 * @param int $receiver_id User id of private message receiver
+	 * @param string $title Message title/subject
+	 * @param string $message Message body/content
+	 * @return bool Send successful/failed
+	 */
+	public function send_pm( $sender_id, $receiver_id, $title, $message ){
+
+		if ( !is_numeric($receiver_id) or $sender_id == $receiver_id ){
+			$this->error($this->CI->lang->line('aauth_error_self_pm'));
+			return false;
+		}
+
+		$query = $this->CI->db->where('id', $receiver_id);
+		$query = $this->CI->db->where('banned', 0);
+
+		$query = $this->CI->db->get( $this->config_vars['users'] );
+
+		// if user not exist or banned
+		if ( $query->num_rows() < 1 ){
+			$this->error($this->CI->lang->line('aauth_error_no_user'));
+			return false;
+		}
+
+		$query = $this->CI->db->where('id', $sender_id);
+		$query = $this->CI->db->where('banned', 0);
+
+		$query = $this->CI->db->get( $this->config_vars['users'] );
+
+		// if user not exist or banned
+		if ( $query->num_rows() < 1 ){
+			$this->error($this->CI->lang->line('aauth_error_no_user'));
+			return false;
+		}
+
+
+		$data = array(
+			'sender_id' => $sender_id,
+			'receiver_id' => $receiver_id,
+			'title' => $title,
+			'message' => $message,
+			'date' => date('Y-m-d H:i:s')
+		);
+
+		return $query = $this->CI->db->insert( $this->config_vars['pms'], $data );
+	}
+
+	//tested
+	/**
+	 * List Private Messages
+	 * If receiver id not given retruns current user's pms, if sender_id given, it returns only pms from given sender
+	 * @param int $limit Number of private messages to be returned
+	 * @param int $offset Offset for private messages to be returned (for pagination)
+	 * @param int $sender_id User id of private message sender
+	 * @param int $receiver_id User id of private message receiver
+	 * @return object Array of private messages
+	 */
+	public function list_pms($limit=5, $offset=0, $receiver_id = false, $sender_id=false){
+
+		$query='';
+
+		if ( $receiver_id != false){
+			$query = $this->CI->db->where('receiver_id', $receiver_id);
+		}
+
+		if( $sender_id != false ){
+			$query = $this->CI->db->where('sender_id', $sender_id);
+		}
+
+		$query = $this->CI->db->order_by('id','DESC');
+		$query = $this->CI->db->get( $this->config_vars['pms'], $limit, $offset);
+		return $query->result();
+	}
+
+	//tested
+	/**
+	 * Get Private Message
+	 * Get private message by id
+	 * @param int $pm_id Private message id to be returned
+	 * @param bool $set_as_read Whether or not to mark message as read
+	 * @return object Private message
+	 */
+	public function get_pm($pm_id, $set_as_read = true){
+
+		$query = $this->CI->db->where('id', $pm_id);
+		$query = $this->CI->db->get( $this->config_vars['pms'] );
+
+		if ($query->num_rows() < 1) {
+			$this->error( $this->CI->lang->line('aauth_error_no_pm') );
+		}
+
+		if ($set_as_read) $this->set_as_read_pm($pm_id);
+
+		return $query->result();
+	}
+
+	//tested
+	/**
+	 * Delete Private Message
+	 * Delete private message by id
+	 * @param int $pm_id Private message id to be deleted
+	 * @return bool Delete success/failure
+	 */
+	public function delete_pm($pm_id){
+		
+		return $this->CI->db->delete( $this->config_vars['pms'], array('id' => $pm_id) );
+	}
+
+	//tested
+	/**
+	 * Count unread Private Message
+	 * Count number of unread private messages
+	 * @param int|bool $receiver_id User id for message receiver, if false returns for current user
+	 * @return int Number of unread messages
+	 */
+	public function count_unread_pms($receiver_id=false){
+
+		if(!$receiver_id){
+			$receiver_id = $this->CI->session->userdata('id');
+		}
+
+		$query = $this->CI->db->where('receiver_id', $receiver_id);
+		$query = $this->CI->db->where('read', 0);
+		$query = $this->CI->db->get( $this->config_vars['pms'] );
+
+		return $query->num_rows();
+	}
+
+	//tested
+	/**
+	 * Set Private Message as read
+	 * Set private message as read
+	 * @param int $pm_id Private message id to mark as read
+	 */
+	public function set_as_read_pm($pm_id){
+
+		$data = array(
+			'read' => 1,
+		);
+
+		$this->CI->db->update( $this->config_vars['pms'], $data, "id = $pm_id");
+	}
+
+	########################
+	# Error / Info Functions
+	########################
+
+	/**
+	 * Error
+	 * Add message to error array and set flash data
+	 * @param string $message Message to add to array
+	 * @param boolean $flashdata if true add $message to CI flashdata (deflault: false)
+	 */
+	public function error($message = '', $flashdata = false){
+		$this->errors[] = $message;
+		if($flashdata) {
 			$this->CI->session->set_flashdata('errors', $this->errors);
 		}
-    }
+	}
 
-    /**
-     * Keep Errors
-     * keeps the flash data flash data
-     * Benefitial by using Ajax Requests
-     * more info about flash data
-     * http://ellislab.com/codeigniter/user-guide/libraries/sessions.html
-     */
-    public function keep_errors(){
-        $this->CI->session->keep_flashdata('errors');
-    }
+	/**
+	 * Keep Errors
+	 * keeps the flash data flash data
+	 * Benefitial by using Ajax Requests
+	 * more info about flash data
+	 * http://ellislab.com/codeigniter/user-guide/libraries/sessions.html
+	 */
+	public function keep_errors(){
+		$this->CI->session->keep_flashdata('errors');
+	}
 
-    //tested
-    /**
-     * Get Errors Array
-     * Return array of errors
-     * @return array Array of messages, empty array if no errors
-     */
-    public function get_errors_array(){
+	//tested
+	/**
+	 * Get Errors Array
+	 * Return array of errors
+	 * @return array Array of messages, empty array if no errors
+	 */
+	public function get_errors_array(){
 
-        if (!count($this->errors)==0){
-            return $this->errors;
-        } else {
-            return array();
-        }
-    }
+		if (!count($this->errors)==0){
+			return $this->errors;
+		} else {
+			return array();
+		}
+	}
 
-    //tested
-    /**
-     * Print Errors
-     * Prints string of errors separated by delimiter
-     * @param string $divider Separator for errors
-     */
-    public function print_errors($divider = '<br />'){
+	//tested
+	/**
+	 * Print Errors
+	 * Prints string of errors separated by delimiter
+	 * @param string $divider Separator for errors
+	 */
+	public function print_errors($divider = '<br />'){
 
-        $msg = '';
-        $msg_num = count($this->errors);
-        $i = 1;
-        foreach ($this->errors as $e) {
-            $msg .= $e;
+		$msg = '';
+		$msg_num = count($this->errors);
+		$i = 1;
+		foreach ($this->errors as $e) {
+			$msg .= $e;
 
-            if ($i != $msg_num)
-                $msg .= $divider;
+			if ($i != $msg_num)
+				$msg .= $divider;
 
-            $i++;
-        }
-        echo $msg;
-    }
-    
-    /**
-     * Clear Errors
-     * 
-     * Removes errors from error list and clears all associated flashdata
-     */
-    public function clear_errors() {
-    	$this->errors = [];
-    	$this->CI->session->set_flashdata('errors', $this->errors);
-    }
+			$i++;
+		}
+		echo $msg;
+	}
+	
+	/**
+	 * Clear Errors
+	 * 
+	 * Removes errors from error list and clears all associated flashdata
+	 */
+	public function clear_errors() {
+		$this->errors = [];
+		$this->CI->session->set_flashdata('errors', $this->errors);
+	}
 
-    //tested
-    /**
-     * Info
-     *
-     * Add message to info array and set flash data
-     * 
-     * @param string $message Message to add to infos array
-     * @param boolean $flashdata if true add $message to CI flashdata (deflault: false)
-     */
-    public function info($message = '', $flashdata = false){
+	//tested
+	/**
+	 * Info
+	 *
+	 * Add message to info array and set flash data
+	 * 
+	 * @param string $message Message to add to infos array
+	 * @param boolean $flashdata if true add $message to CI flashdata (deflault: false)
+	 */
+	public function info($message = '', $flashdata = false){
 
-        $this->infos[] = $message;
-        if($flashdata) {
+		$this->infos[] = $message;
+		if($flashdata) {
 			$this->CI->session->set_flashdata('infos', $this->infos);
 		}
-    }
+	}
 
-    /**
-     * Keep Infos
-     * keeps the flash data
-     * Benefitial by using Ajax Requests
-     * more info about flash data
-     * http://ellislab.com/codeigniter/user-guide/libraries/sessions.html
-     */
-    public function keep_infos(){
-        $this->CI->session->keep_flashdata('infos');
-    }
+	/**
+	 * Keep Infos
+	 * keeps the flash data
+	 * Benefitial by using Ajax Requests
+	 * more info about flash data
+	 * http://ellislab.com/codeigniter/user-guide/libraries/sessions.html
+	 */
+	public function keep_infos(){
+		$this->CI->session->keep_flashdata('infos');
+	}
 
-    //tested
-    /**
-     * Get Info Array
-     * Return array of info
-     * @return array Array of messages, empty array if no errors
-     */
-    public function get_infos_array(){
+	//tested
+	/**
+	 * Get Info Array
+	 * Return array of info
+	 * @return array Array of messages, empty array if no errors
+	 */
+	public function get_infos_array(){
 
-        if (!count($this->infos)==0){
-            return $this->infos;
-        } else {
-            return array();
-        }
-    }
+		if (!count($this->infos)==0){
+			return $this->infos;
+		} else {
+			return array();
+		}
+	}
 
-    //tested
-    /**
-     * Print Info
-     * Print string of info separated by delimiter
-     * @param string $divider Separator for info
-     *
-     */
-    public function print_infos($divider = '<br />'){
+	//tested
+	/**
+	 * Print Info
+	 * Print string of info separated by delimiter
+	 * @param string $divider Separator for info
+	 *
+	 */
+	public function print_infos($divider = '<br />'){
 
-        $msg = '';
-        $msg_num = count($this->infos);
-        $i = 1;
-        foreach ($this->infos as $e) {
-            $msg .= $e;
+		$msg = '';
+		$msg_num = count($this->infos);
+		$i = 1;
+		foreach ($this->infos as $e) {
+			$msg .= $e;
 
-            if ($i != $msg_num)
-                $msg .= $divider;
+			if ($i != $msg_num)
+				$msg .= $divider;
 
-            $i++;
-        }
-        echo $msg;
-    }
-    
-    /**
-     * Clear Info List
-     * 
-     * Removes info messages from info list and clears all associated flashdata
-     */
-    public function clear_infos() {
-    	$this->infos = [];
-    	$this->CI->session->set_flashdata('infos', $this->infos);
-    }
+			$i++;
+		}
+		echo $msg;
+	}
+	
+	/**
+	 * Clear Info List
+	 * 
+	 * Removes info messages from info list and clears all associated flashdata
+	 */
+	public function clear_infos() {
+		$this->infos = [];
+		$this->CI->session->set_flashdata('infos', $this->infos);
+	}
 
-    ########################
-    # User Variables
-    ########################
+	########################
+	# User Variables
+	########################
 
-    //tested
-    /**
-     * Set User Variable as key value
-     * if variable not set before, it will ve set
-     * if set, overwrites the value
-     * @param string $key
-     * @param string $value
-     * @param int $user_id ; if not given current user
-     * @return bool
-     */
-    public function set_user_var( $key, $value, $user_id = false ) {
+	//tested
+	/**
+	 * Set User Variable as key value
+	 * if variable not set before, it will ve set
+	 * if set, overwrites the value
+	 * @param string $key
+	 * @param string $value
+	 * @param int $user_id ; if not given current user
+	 * @return bool
+	 */
+	public function set_user_var( $key, $value, $user_id = false ) {
 
-        if ( ! $user_id ){
-            $user_id = $this->CI->session->userdata('id');
-        }
+		if ( ! $user_id ){
+			$user_id = $this->CI->session->userdata('id');
+		}
 
-        // if specified user is not found
-        if ( ! $this->get_user($user_id)){
-            return false;
-        }
+		// if specified user is not found
+		if ( ! $this->get_user($user_id)){
+			return false;
+		}
 
-        // if var not set, set
-         if ($this->get_user_var($key,$user_id) ===false) {
+		// if var not set, set
+		 if ($this->get_user_var($key,$user_id) ===false) {
 
-            $data = array(
-                'key' => $key,
-                'value' => $value,
-                'user_id' => $user_id
-            );
+			$data = array(
+				'key' => $key,
+				'value' => $value,
+				'user_id' => $user_id
+			);
 
-            return $this->CI->db->insert( $this->config_vars['user_variables'] , $data);
-        }
-        // if var already set, overwrite
-        else {
+			return $this->CI->db->insert( $this->config_vars['user_variables'] , $data);
+		}
+		// if var already set, overwrite
+		else {
 
-            $data = array(
-                'key' => $key,
-                'value' => $value,
-                'user_id' => $user_id
-            );
+			$data = array(
+				'key' => $key,
+				'value' => $value,
+				'user_id' => $user_id
+			);
 
-            $this->CI->db->where( 'key', $key );
-            $this->CI->db->where( 'user_id', $user_id);
+			$this->CI->db->where( 'key', $key );
+			$this->CI->db->where( 'user_id', $user_id);
 
-            return $this->CI->db->update( $this->config_vars['user_variables'], $data);
-        }
-    }
+			return $this->CI->db->update( $this->config_vars['user_variables'], $data);
+		}
+	}
 
-    //tested
-    /**
-     * Unset User Variable as key value
-     * @param string $key
-     * @param int $user_id ; if not given current user
-     * @return bool
-     */
-    public function unset_user_var( $key, $user_id = false ) {
+	//tested
+	/**
+	 * Unset User Variable as key value
+	 * @param string $key
+	 * @param int $user_id ; if not given current user
+	 * @return bool
+	 */
+	public function unset_user_var( $key, $user_id = false ) {
 
-        if ( ! $user_id ){
-            $user_id = $this->CI->session->userdata('id');
-        }
+		if ( ! $user_id ){
+			$user_id = $this->CI->session->userdata('id');
+		}
 
-        // if specified user is not found
-        if ( ! $this->get_user($user_id)){
-            return false;
-        }
+		// if specified user is not found
+		if ( ! $this->get_user($user_id)){
+			return false;
+		}
 
-        $this->CI->db->where('key', $key);
-        $this->CI->db->where('user_id', $user_id);
+		$this->CI->db->where('key', $key);
+		$this->CI->db->where('user_id', $user_id);
 
-        return $this->CI->db->delete( $this->config_vars['user_variables'] );
-    }
+		return $this->CI->db->delete( $this->config_vars['user_variables'] );
+	}
 
-    //tested
-    /**
-     * Get User Variable by key
-     * Return string of variable value or false
-     * @param string $key
-     * @param int $user_id ; if not given current user
-     * @return bool|string , false if var is not set, the value of var if set
-     */
-    public function get_user_var( $key, $user_id = false){
+	//tested
+	/**
+	 * Get User Variable by key
+	 * Return string of variable value or false
+	 * @param string $key
+	 * @param int $user_id ; if not given current user
+	 * @return bool|string , false if var is not set, the value of var if set
+	 */
+	public function get_user_var( $key, $user_id = false){
 
-        if ( ! $user_id ){
-            $user_id = $this->CI->session->userdata('id');
-        }
+		if ( ! $user_id ){
+			$user_id = $this->CI->session->userdata('id');
+		}
 
-        // if specified user is not found
-        if ( ! $this->get_user($user_id)){
-            return false;
-        }
+		// if specified user is not found
+		if ( ! $this->get_user($user_id)){
+			return false;
+		}
 
-        $query = $this->CI->db->where('user_id', $user_id);
-        $query = $this->CI->db->where('key', $key);
+		$query = $this->CI->db->where('user_id', $user_id);
+		$query = $this->CI->db->where('key', $key);
 
-        $query = $this->CI->db->get( $this->config_vars['user_variables'] );
+		$query = $this->CI->db->get( $this->config_vars['user_variables'] );
 
-        // if variable not set
-        if ($query->num_rows() < 1) { return false;}
+		// if variable not set
+		if ($query->num_rows() < 1) { return false;}
 
-        else {
+		else {
 
-            $row = $query->row();
-            return $row->value;
-        }
+			$row = $query->row();
+			return $row->value;
+		}
 
-    }
-    
+	}
+	
    
-    /**
-     * List User Variable Keys by UserID
-     * Return array of variable keys or false
-     * @param int $user_id ; if not given current user
-     * @return bool|string , false if var is not set, the value of var if set
-     */
-    public function list_user_var_keys($user_id = false){
+	/**
+	 * List User Variable Keys by UserID
+	 * Return array of variable keys or false
+	 * @param int $user_id ; if not given current user
+	 * @return bool|array, false if no user vars, otherwise array
+	 */
+	public function list_user_var_keys($user_id = false){
 
-        if ( ! $user_id ){
-            $user_id = $this->CI->session->userdata('id');
-        }
+		if ( ! $user_id ){
+			$user_id = $this->CI->session->userdata('id');
+		}
 
-        // if specified user is not found
-        if ( ! $this->get_user($user_id)){
-            return false;
-        }
-        $query = $this->CI->db->select('key');
+		// if specified user is not found
+		if ( ! $this->get_user($user_id)){
+			return false;
+		}
+		$query = $this->CI->db->select('key');
 
-        $query = $this->CI->db->where('user_id', $user_id);
+		$query = $this->CI->db->where('user_id', $user_id);
 
-        $query = $this->CI->db->get( $this->config_vars['user_variables'] );
+		$query = $this->CI->db->get( $this->config_vars['user_variables'] );
 
-        // if variable not set
-        if ($query->num_rows() < 1) { return false;}
-        else {
-            return $query->result();
-        }
+		// if variable not set
+		if ($query->num_rows() < 1) { return false;}
+		else {
+			$key_list = array();
+			foreach( $query->result() as $row) {
+				$key_list[] = $row->key;
+			}
+			return $key_list;
+		}
+	}
 
-    }
+	########################
+	# Aauth System Variables
+	########################
 
-    ########################
-    # Aauth System Variables
-    ########################
+	//tested
+	/**
+	 * Set Aauth System Variable as key value
+	 * if variable not set before, it will be set
+	 * if set, overwrites the value
+	 * @param string $key
+	 * @param string $value
+	 * @return bool
+	 */
+	public function set_system_var( $key, $value ) {
 
-    //tested
-    /**
-     * Set Aauth System Variable as key value
-     * if variable not set before, it will be set
-     * if set, overwrites the value
-     * @param string $key
-     * @param string $value
-     * @return bool
-     */
-    public function set_system_var( $key, $value ) {
+		// if var not set, set
+		if ( ! $this->get_system_var($key) ) {
 
-        // if var not set, set
-        if ( ! $this->get_system_var($key) ) {
+			$data = array(
+				'key' => $key,
+				'value' => $value,
+			);
 
-            $data = array(
-                'key' => $key,
-                'value' => $value,
-            );
+			return $this->CI->db->insert( $this->config_vars['system_variables'] , $data);
 
-            return $this->CI->db->insert( $this->config_vars['system_variables'] , $data);
+		}
+		// if var already set, overwrite
+		else {
 
-        }
-        // if var already set, overwrite
-        else {
+			$data = array(
+				'key' => $key,
+				'value' => $value,
+			);
 
-            $data = array(
-                'key' => $key,
-                'value' => $value,
-            );
+			$this->CI->db->where( 'key', $key );
+			return $this->CI->db->update( $this->config_vars['system_variables'], $data);
+		}
 
-            $this->CI->db->where( 'key', $key );
-            return $this->CI->db->update( $this->config_vars['system_variables'], $data);
-        }
+	}
 
-    }
+	//tested
+	/**
+	 * Unset Aauth System Variable as key value
+	 * @param string $key
+	 * @return bool
+	 */
+	public function unset_system_var( $key	) {
 
-    //tested
-    /**
-     * Unset Aauth System Variable as key value
-     * @param string $key
-     * @return bool
-     */
-    public function unset_system_var( $key  ) {
+		$this->CI->db->where('key', $key);
 
-        $this->CI->db->where('key', $key);
+		return $this->CI->db->delete( $this->config_vars['system_variables'] );
+	}
 
-        return $this->CI->db->delete( $this->config_vars['system_variables'] );
-    }
+	//tested
+	/**
+	 * Get Aauth System Variable by key
+	 * Return string of variable value or false
+	 * @param string $key
+	 * @return bool|string , false if var is not set, the value of var if set
+	 */
+	public function get_system_var( $key ){
 
-    //tested
-    /**
-     * Get Aauth System Variable by key
-     * Return string of variable value or false
-     * @param string $key
-     * @return bool|string , false if var is not set, the value of var if set
-     */
-    public function get_system_var( $key ){
+		$query = $this->CI->db->where('key', $key);
 
-        $query = $this->CI->db->where('key', $key);
+		$query = $this->CI->db->get( $this->config_vars['system_variables'] );
 
-        $query = $this->CI->db->get( $this->config_vars['system_variables'] );
+		// if variable not set
+		if ($query->num_rows() < 1) { return false;}
 
-        // if variable not set
-        if ($query->num_rows() < 1) { return false;}
+		else {
 
-        else {
+			$row = $query->row();
+			return $row->value;
+		}
+	}
+	
+	 /**
+	 * List System Variable Keys
+	 * Return array of variable keys or false
+	 * @return bool|array , false if var is not set, the value of var if set
+	 */
 
-            $row = $query->row();
-            return $row->value;
-        }
-    }
-    
-     /**
-     * List System Variable Keys
-     * Return array of variable keys or false
-     * @return bool|array , false if var is not set, the value of var if set
-     */
+	public function list_system_var_keys(){
+		$query = $this->CI->db->select('key');
+		$query = $this->CI->db->get( $this->config_vars['system_variables'] );
+		// if variable not set
+		if ($query->num_rows() < 1) { return false;}
+		else {
+			return $query->result();
+		}
+	}
 
-    public function list_system_var_keys(){
-        $query = $this->CI->db->select('key');
-        $query = $this->CI->db->get( $this->config_vars['system_variables'] );
-        // if variable not set
-        if ($query->num_rows() < 1) { return false;}
-        else {
-            return $query->result();
-        }
-    }
-
-    public function generate_recaptcha_field(){
-        $content = '';
-        if($this->config_vars['ddos_protection'] and $this->config_vars['recaptcha_active'] and $this->CI->input->cookie('reCAPTCHA', TRUE) == 'true'){
-            $content .= "<script type='text/javascript' src='https://www.google.com/recaptcha/api.js'></script>";
-            $siteKey = $this->config_vars['recaptcha_siteKey'];
-            $content .= "<div class='g-recaptcha' data-sitekey='{$siteKey}'></div>";
-        }
-        return $content;
-    }
+	public function generate_recaptcha_field(){
+		$content = '';
+		if($this->config_vars['ddos_protection'] and $this->config_vars['recaptcha_active'] and $this->CI->input->cookie('reCAPTCHA', TRUE) == 'true'){
+			$content .= "<script type='text/javascript' src='https://www.google.com/recaptcha/api.js'></script>";
+			$siteKey = $this->config_vars['recaptcha_siteKey'];
+			$content .= "<div class='g-recaptcha' data-sitekey='{$siteKey}'></div>";
+		}
+		return $content;
+	}
 
 } // end class
 
@@ -2073,7 +2075,7 @@ class Aauth {
  * tamam // login e ip aderesi de eklemek lazım
  * list_users da grup_par verilirse ve adamın birden fazla grubu varsa nolurkun? // bi denemek lazım belki distinct ile düzelir
  * tamam // eğer grup silinmişse kullanıcıları da o gruptan sil (fire)
- * tamam //  ismember la is admine 2. parametre olarak user id ekle
+ * tamam //	 ismember la is admine 2. parametre olarak user id ekle
  * tamam // kepp infos errors die bişey yap ajax requestlerinde silinir errorlar
  * tmam // user variables
  * tamam // sistem variables

--- a/application/libraries/Aauth.php
+++ b/application/libraries/Aauth.php
@@ -53,6 +53,25 @@ class Aauth {
 	 * @var array
 	 */
 	public $infos = array();
+	
+	/**
+	 * Local temporary storage for current flash errors
+	 *
+	 * Used to update current flash data list since flash data is only available on the next page refresh
+	 * @access public
+	 * var array
+	 */
+	public $flash_errors = array();
+
+	/**
+	 * Local temporary storage for current flash infos
+	 *
+	 * Used to update current flash data list since flash data is only available on the next page refresh
+	 * @access public
+	 * var array
+	 */
+	public $flash_infos = array();
+
 
 	########################
 	# Base Functions
@@ -1664,7 +1683,8 @@ class Aauth {
 	public function error($message = '', $flashdata = false){
 		$this->errors[] = $message;
 		if($flashdata) {
-			$this->CI->session->set_flashdata('errors', $this->errors);
+			$this->flash_errors[] = $message;
+			$this->CI->session->set_flashdata('errors', $this->flash_errors);
 		}
 	}
 
@@ -1739,7 +1759,8 @@ class Aauth {
 
 		$this->infos[] = $message;
 		if($flashdata) {
-			$this->CI->session->set_flashdata('infos', $this->infos);
+			$this->flash_infos[] = $message;
+			$this->CI->session->set_flashdata('infos', $this->flash_infos);
 		}
 	}
 

--- a/application/libraries/Aauth.php
+++ b/application/libraries/Aauth.php
@@ -1690,13 +1690,24 @@ class Aauth {
 
 	/**
 	 * Keep Errors
-	 * keeps the flash data flash data
-	 * Benefitial by using Ajax Requests
-	 * more info about flash data
-	 * http://ellislab.com/codeigniter/user-guide/libraries/sessions.html
+	 *
+	 * Keeps the flashdata errors for one more page refresh.  Optionally adds the default errors into the
+	 * flashdata list.  This should be called last in your controller, and with care as it could continue
+	 * to revive all errors and not let them expire as intended.
+	 * Benefitial when using Ajax Requests
+	 * @see http://ellislab.com/codeigniter/user-guide/libraries/sessions.html
+	 * @param boolean $include_non_flash true if it should stow basic errors as flashdata (default = false)
 	 */
-	public function keep_errors(){
-		$this->CI->session->keep_flashdata('errors');
+	public function keep_errors($include_non_flash = FALSE)
+	{
+		// NOTE: keep_flashdata() overwrites anything new that has been added to flashdata so we are manually reviving flash data
+		// $this->CI->session->keep_flashdata('errors');
+
+		if($include_non_flash) {
+			$this->flash_errors = array_merge($this->flash_errors, $this->errors);
+		}
+		$this->flash_errors = array_merge($this->flash_errors, (array)$this->CI->session->flashdata('errors'));
+		$this->CI->session->set_flashdata('errors', $this->flash_errors);
 	}
 
 	//tested
@@ -1766,16 +1777,26 @@ class Aauth {
 
 	/**
 	 * Keep Infos
-	 * keeps the flash data
+	 *
+	 * Keeps the flashdata infos for one more page refresh.  Optionally adds the default infos into the
+	 * flashdata list.  This should be called last in your controller, and with care as it could continue
+	 * to revive all infos and not let them expire as intended.
 	 * Benefitial by using Ajax Requests
-	 * more info about flash data
-	 * http://ellislab.com/codeigniter/user-guide/libraries/sessions.html
+	 * @see http://ellislab.com/codeigniter/user-guide/libraries/sessions.html
+	 * @param boolean $include_non_flash true if it should stow basic infos as flashdata (default = false)
 	 */
-	public function keep_infos(){
-		$this->CI->session->keep_flashdata('infos');
+	public function keep_infos($include_non_flash = FALSE)
+	{
+		// NOTE: keep_flashdata() overwrites anything new that has been added to flashdata so we are manually reviving flash data
+		// $this->CI->session->keep_flashdata('infos');
+
+		if($include_non_flash) {
+			$this->flash_infos = array_merge($this->flash_infos, $this->infos);
+		}
+		$this->flash_infos = array_merge($this->flash_infos, (array)$this->CI->session->flashdata('infos'));
+		$this->CI->session->set_flashdata('infos', $this->flash_infos);
 	}
 
-	//tested
 	/**
 	 * Get Info Array
 	 * Return array of info

--- a/application/libraries/Aauth.php
+++ b/application/libraries/Aauth.php
@@ -1087,7 +1087,7 @@ class Aauth {
 
         if( ! $group_id ) {
 
-            $this->error( $this->CI->lang->line('group_exist') );
+            $this->error( $this->CI->lang->line('no_group') );
             return false;
         }
 
@@ -1485,7 +1485,7 @@ class Aauth {
      * Get permission id
      * Get permission id from permisison name or id
      * @param int|string $perm_par Permission id or name to get
-     * @return int Permission id
+     * @return int Permission id or NULL if perm does not exist
      */
     public function get_perm_id($perm_par) {
 
@@ -1495,7 +1495,7 @@ class Aauth {
         $query = $this->CI->db->get($this->config_vars['perms']);
 
         if ($query->num_rows() == 0)
-            return false;
+            return NULL;
 
         $row = $query->row();
         return $row->id;

--- a/application/libraries/Aauth.php
+++ b/application/libraries/Aauth.php
@@ -142,13 +142,12 @@ class Aauth {
 		*
 		* Removed or !ctype_alnum($pass) from the IF statement
 		* It was causing issues with special characters in passwords
-		* and returning false even if the password matches.
+		* and returning FALSE even if the password matches.
 		*/
-		if( !valid_email($email) or strlen($pass) < 5 or
-			strlen($pass) > $this->config_vars['max'] )
+		if( !valid_email($email) OR strlen($pass) < 5 OR strlen($pass) > $this->config_vars['max'] )
 		{
 			$this->error($this->CI->lang->line('aauth_error_login_failed'));
-			return false;
+			return FALSE;
 		}
 
 
@@ -161,7 +160,7 @@ class Aauth {
 		if ($query->num_rows() > 0 && $this->config_vars['ddos_protection'] && ! $this->update_login_attempts($row->email)) {
 
 			$this->error($this->CI->lang->line('aauth_error_login_attempts_exceeded'));
-			return false;
+			return FALSE;
 		}
 
 		//recaptcha login_attempts check
@@ -188,7 +187,7 @@ class Aauth {
 
 		if ($query->num_rows() > 0) {
 			$this->error($this->CI->lang->line('aauth_error_account_not_verified'));
-			return false;
+			return FALSE;
 		}
 
 		// to find user id, create sessions and cookies
@@ -197,7 +196,7 @@ class Aauth {
 		
 		if($query->num_rows() == 0){
 			$this->error($this->CI->lang->line('aauth_error_login_failed'));
-			return false;
+			return FALSE;
 		}
 		
 		$user_id = $query->row()->id;
@@ -218,7 +217,7 @@ class Aauth {
 
 			if(!$resp->success){
 				$this->error($this->CI->lang->line('aauth_error_recaptcha_not_correct'));
-				return false;
+				return FALSE;
 			}
 		}
 	 
@@ -286,15 +285,15 @@ class Aauth {
 	public function is_loggedin() {
 
 		if ( $this->CI->session->userdata('loggedin') )
-		{ return true; }
+		{ return TRUE; }
 
 		// cookie control
 		else {
 			if( ! $this->CI->input->cookie('user', TRUE) ){
-				return false;
+				return FALSE;
 			} else {
 				$cookie = explode('-', $this->CI->input->cookie('user', TRUE));
-				if(!is_numeric( $cookie[0] ) or strlen($cookie[1]) < 13 ){return false;}
+				if(!is_numeric( $cookie[0] ) OR strlen($cookie[1]) < 13 ){return FALSE;}
 				else{
 					$query = $this->CI->db->where('id', $cookie[0]);
 					$query = $this->CI->db->where('remember_exp', $cookie[1]);
@@ -304,16 +303,16 @@ class Aauth {
 
 					if ($query->num_rows() < 1) {
 						$this->update_remember($cookie[0]);
-						return false;
+						return FALSE;
 					}else{
 
 						if(strtotime($row->remember_time) > strtotime("now") ){
 							$this->login_fast($cookie[0]);
-							return true;
+							return TRUE;
 						}
 						// if time is expired
 						else {
-							return false;
+							return FALSE;
 						}
 					}
 				}
@@ -321,7 +320,7 @@ class Aauth {
 			}
 		}
 
-		return false;
+		return FALSE;
 	}
 
 	/**
@@ -334,13 +333,13 @@ class Aauth {
 	 *
 	 * @param bool $perm_par If not given just control user logged in or not
 	 */
-	public function control( $perm_par = false ){
+	public function control( $perm_par = FALSE ){
 
 		$perm_id = $this->get_perm_id($perm_par);
 		$this->update_activity();
 
 		// if user or user's group not allowed
-		if ( ! $this->is_allowed($perm_id) or ! $this->is_group_allowed($perm_id) ){
+		if ( ! $this->is_allowed($perm_id) OR ! $this->is_group_allowed($perm_id) ){
 			if( $this->config_vars['no_permission'] ) {
 				$this->error($this->CI->lang->line('aauth_error_no_access'));
 				redirect($this->config_vars['no_permission']);
@@ -377,7 +376,7 @@ class Aauth {
 	 * Fast login
 	 * Login with just a user id
 	 * @param int $user_id User id to log in
-	 * @return bool true if login successful.
+	 * @return bool TRUE if login successful.
 	 */
 	public function login_fast($user_id){
 
@@ -399,9 +398,9 @@ class Aauth {
 			);
 
 			$this->CI->session->set_userdata($data);
-			return true;
+			return TRUE;
 		}
-		return false;
+		return FALSE;
 	}
 
 	/**
@@ -479,17 +478,17 @@ class Aauth {
 			$this->CI->email->message($this->CI->lang->line('aauth_email_reset_success_new_password') . $pass);
 			$this->CI->email->send();
 
-			return true;
+			return TRUE;
 		}
 
-		return false;
+		return FALSE;
 	}
 
 	//tested
 	/**
 	 * Update last login
 	 * Update user's last login date
-	 * @param int|bool $user_id User id to update or false for current user
+	 * @param int|bool $user_id User id to update or FALSE for current user
 	 * @return bool Update fails/succeeds
 	 */
 	public function update_last_login($user_id = FALSE) {
@@ -507,7 +506,7 @@ class Aauth {
 
 	//tested
 	/**
-	 * Update login attempt and if exceeds return false
+	 * Update login attempt and if exceeds return FALSE
 	 * Update user's last login attemp date and number date
 	 * @param string $email User email
 	 * @return bool
@@ -540,9 +539,9 @@ class Aauth {
 		}
 
 		if ( $data['login_attempts'] > $this->config_vars['max_login_attempt'] ) {
-			return false;
+			return FALSE;
 		} else {
-			return true;
+			return TRUE;
 		}
 
 	}
@@ -580,37 +579,37 @@ class Aauth {
 	 */
 	public function create_user($email, $pass, $name) {
 
-		$valid = true;
+		$valid = TRUE;
 
 		// if email is already exist
 		if ($this->user_exsist_by_email($email)) {
 			$this->error($this->CI->lang->line('aauth_error_email_exists'));
-			$valid = false;
+			$valid = FALSE;
 		}
 		if ($this->user_exsist_by_name($name)) {
 			$this->error($this->CI->lang->line('aauth_error_username_exists'));
-			$valid = false;
+			$valid = FALSE;
 		}
 
 		if ( ! valid_email($email)){
 			$this->error($this->CI->lang->line('aauth_error_email_invalid'));
-			$valid = false;
+			$valid = FALSE;
 		}
-		if ( strlen($pass) < 5 or strlen($pass) > $this->config_vars['max'] ){
+		if ( strlen($pass) < 5 OR strlen($pass) > $this->config_vars['max'] ){
 			$this->error($this->CI->lang->line('aauth_error_password_invalid'));
-			$valid = false;
+			$valid = FALSE;
 		}
-		if ($name !='' and !ctype_alnum(str_replace($this->config_vars['valid_chars'], '', $name))){
+		if ($name !='' && !ctype_alnum(str_replace($this->config_vars['valid_chars'], '', $name))){
 			$this->error($this->CI->lang->line('aauth_error_username_invalid'));
-			$valid = false;
+			$valid = FALSE;
 		}
 		if (empty($name)){
 			$this->error($this->CI->lang->line('aauth_error_username_required'));
-			$valid = false;
+			$valid = FALSE;
 		}
 
 		if (!$valid) {
-			return false; }
+			return FALSE; }
 
 		$data = array(
 			'email' => $email,
@@ -655,9 +654,9 @@ class Aauth {
 	 * Update user
 	 * Updates existing user details
 	 * @param int $user_id User id to update
-	 * @param string|bool $email User's email address, or false if not to be updated
-	 * @param string|bool $pass User's password, or false if not to be updated
-	 * @param string|bool $name User's name, or false if not to be updated
+	 * @param string|bool $email User's email address, or FALSE if not to be updated
+	 * @param string|bool $pass User's password, or FALSE if not to be updated
+	 * @param string|bool $name User's name, or FALSE if not to be updated
 	 * @return bool Update fails/succeeds
 	 */
 	public function update_user($user_id, $email = FALSE, $pass = FALSE, $name = FALSE) {
@@ -684,7 +683,7 @@ class Aauth {
 	/**
 	 * List users
 	 * Return users as an object array
-	 * @param bool|int $group_par Specify group id to list group or false for all users
+	 * @param bool|int $group_par Specify group id to list group or FALSE for all users
 	 * @param string $limit Limit of users to be returned
 	 * @param bool $offset Offset for limited number of users
 	 * @param bool $include_banneds Include banned users
@@ -731,7 +730,7 @@ class Aauth {
 	/**
 	 * Get user
 	 * Get user information
-	 * @param int|bool $user_id User id to get or false for current user
+	 * @param int|bool $user_id User id to get or FALSE for current user
 	 * @return object User information
 	 */
 	public function get_user($user_id = FALSE) {
@@ -762,7 +761,7 @@ class Aauth {
 		$query = $this->CI->db->where('verification_code', $ver_code);
 		$query = $this->CI->db->get( $this->config_vars['users'] );
 
-		// if ver code is true
+		// if ver code is TRUE
 		if( $query->num_rows() > 0 ){
 
 			$data =	 array(
@@ -772,9 +771,9 @@ class Aauth {
 
 			$this->CI->db->where('id', $user_id);
 			$this->CI->db->update($this->config_vars['users'] , $data);
-			return true;
+			return TRUE;
 		}
-		return false;
+		return FALSE;
 	}
 
 	/**
@@ -949,7 +948,7 @@ class Aauth {
 	 * @param string|bool $email Email address for user
 	 * @return int User id
 	 */
-	public function get_user_id($email=false) {
+	public function get_user_id($email=FALSE) {
 
 		if( ! $email){
 			$query = $this->CI->db->where('id', $this->CI->session->userdata('id'));
@@ -969,12 +968,12 @@ class Aauth {
 	/**
 	 * Get user groups
 	 * Get groups a user is in
-	 * @param int|bool $user_id User id to get or false for current user
+	 * @param int|bool $user_id User id to get or FALSE for current user
 	 * @return array Groups
 	 */
-	public function get_user_groups($user_id = false){
+	public function get_user_groups($user_id = FALSE){
 
-		if ($user_id==false) { $user_id = $this->CI->session->userdata('id'); }
+		if ($user_id==FALSE) { $user_id = $this->CI->session->userdata('id'); }
 
 		$this->CI->db->select('*');
 		$this->CI->db->from($this->config_vars['user_to_group']);
@@ -988,7 +987,7 @@ class Aauth {
 	/**
 	 * Update activity
 	 * Update user's last activity date
-	 * @param int|bool $user_id User id to update or false for current user
+	 * @param int|bool $user_id User id to update or FALSE for current user
 	 * @return bool Update fails/succeeds
 	 */
 	public function update_activity($user_id = FALSE) {
@@ -996,7 +995,7 @@ class Aauth {
 		if ($user_id == FALSE)
 			$user_id = $this->CI->session->userdata('id');
 
-		if($user_id==false){return false;}
+		if($user_id==FALSE){return FALSE;}
 
 		$data['last_activity'] = date("Y-m-d H:i:s");
 
@@ -1028,7 +1027,7 @@ class Aauth {
 	 * Create group
 	 * Creates a new group
 	 * @param string $group_name New group name
-	 * @return int|bool Group id or false on fail
+	 * @return int|bool Group id or FALSE on fail
 	 */
 	public function create_group($group_name) {
 
@@ -1079,7 +1078,7 @@ class Aauth {
 	$this->CI->db->where('id',$group_id);
 	$query = $this->CI->db->get($this->config_vars['groups']);
 	if ($query->num_rows() == 0){
-		return false;
+		return FALSE;
 	}
 
 		// bug fixed
@@ -1106,7 +1105,7 @@ class Aauth {
 		if( ! $group_id ) {
 
 			$this->error( $this->CI->lang->line('aauth_error_no_group') );
-			return false;
+			return FALSE;
 		}
 
 		$query = $this->CI->db->where('user_id',$user_id);
@@ -1122,7 +1121,7 @@ class Aauth {
 			return $this->CI->db->insert($this->config_vars['user_to_group'], $data);
 		}
 		$this->info($this->CI->lang->line('aauth_info_already_member'));
-		return true;
+		return TRUE;
 	}
 
 	//tested
@@ -1149,9 +1148,9 @@ class Aauth {
 	 * @param int|bool $user_id User id, if not given current user
 	 * @return bool
 	 */
-	public function is_member( $group_par, $user_id = false ) {
+	public function is_member( $group_par, $user_id = FALSE ) {
 
-		// if user_id false (not given), current user
+		// if user_id FALSE (not given), current user
 		if( ! $user_id){
 			$user_id = $this->CI->session->userdata('id');
 		}
@@ -1178,7 +1177,7 @@ class Aauth {
 	 * @param int $user_id User id to check, if it is not given checks current user
 	 * @return bool
 	 */
-	public function is_admin( $user_id = false ) {
+	public function is_admin( $user_id = FALSE ) {
 
 		return $this->is_member($this->config_vars['admin_group'], $user_id);
 	}
@@ -1246,7 +1245,7 @@ class Aauth {
 	 * Creates a new permission type
 	 * @param string $perm_name New permission name
 	 * @param string $definition Permission description
-	 * @return int|bool Permission id or false on fail
+	 * @return int|bool Permission id or FALSE on fail
 	 */
 	public function create_perm($perm_name, $definition='') {
 
@@ -1274,14 +1273,14 @@ class Aauth {
 	 * @param string $definition Permission description
 	 * @return bool Update success/failure
 	 */
-	public function update_perm($perm_par, $perm_name=false, $definition=false) {
+	public function update_perm($perm_par, $perm_name=FALSE, $definition=FALSE) {
 
 		$perm_id = $this->get_perm_id($perm_par);
 
-		if ($perm_name != false)
+		if ($perm_name != FALSE)
 			$data['name'] = $perm_name;
 
-		if ($definition != false)
+		if ($definition != FALSE)
 			$data['definition'] = $definition;
 
 		$this->CI->db->where('id', $perm_id);
@@ -1317,14 +1316,14 @@ class Aauth {
 	 * Check if user allowed to do specified action, admin always allowed
 	 * first checks user permissions then check group permissions
 	 * @param int $perm_par Permission id or name to check
-	 * @param int|bool $user_id User id to check, or if false checks current user
+	 * @param int|bool $user_id User id to check, or if FALSE checks current user
 	 * @return bool
 	 */
-	public function is_allowed($perm_par, $user_id=false){
+	public function is_allowed($perm_par, $user_id=FALSE){
 
 		$perm_id = $this->get_perm_id($perm_par);
 
-		if( $user_id == false){
+		if( $user_id == FALSE){
 			$user_id = $this->CI->session->userdata('id');
 		}
 
@@ -1333,11 +1332,11 @@ class Aauth {
 		$query = $this->CI->db->get( $this->config_vars['perm_to_user'] );
 
 		if( $query->num_rows() > 0){
-			return true;
+			return TRUE;
 		} elseif ($this->is_group_allowed($perm_id)) {
-			return true;
+			return TRUE;
 		} else {
-			return false;
+			return FALSE;
 		}
 
 	}
@@ -1346,15 +1345,15 @@ class Aauth {
 	 * Is Group allowed
 	 * Check if group is allowed to do specified action, admin always allowed
 	 * @param int $perm_par Permission id or name to check
-	 * @param int|string|bool $group_par Group id or name to check, or if false checks all user groups
+	 * @param int|string|bool $group_par Group id or name to check, or if FALSE checks all user groups
 	 * @return bool
 	 */
-	public function is_group_allowed($perm_par, $group_par=false){
+	public function is_group_allowed($perm_par, $group_par=FALSE){
 
 		$perm_id = $this->get_perm_id($perm_par);
 
 		// if group par is given
-		if($group_par != false){
+		if($group_par != FALSE){
 
 			$group_par = $this->get_group_id($group_par);
 
@@ -1363,30 +1362,30 @@ class Aauth {
 			$query = $this->CI->db->get( $this->config_vars['perm_to_group'] );
 
 			if( $query->num_rows() > 0){
-				return true;
+				return TRUE;
 			} else {
-				return false;
+				return FALSE;
 			}
 		}
 		// if group par is not given
 		// checks current user's all groups
 		else {
 			// if public is allowed or he is admin
-			if ( $this->is_admin( $this->CI->session->userdata('id')) or
+			if ( $this->is_admin( $this->CI->session->userdata('id')) OR
 				$this->is_group_allowed($perm_id, $this->config_vars['public_group']) )
-			{return true;}
+			{return TRUE;}
 
 			// if is not login
-			if (!$this->is_loggedin()){return false;}
+			if (!$this->is_loggedin()){return FALSE;}
 
 			$group_pars = $this->get_user_groups();
 
 			foreach ($group_pars as $g ){
 				if($this->is_group_allowed($perm_id, $g -> id)){
-					return true;
+					return TRUE;
 				}
 			}
-			return false;
+			return FALSE;
 		}
 	}
 
@@ -1416,7 +1415,7 @@ class Aauth {
 
 			return $this->CI->db->insert($this->config_vars['perm_to_user'], $data);
 		}
-		return true;
+		return TRUE;
 	}
 
 	//tested
@@ -1464,7 +1463,7 @@ class Aauth {
 			return $this->CI->db->insert($this->config_vars['perm_to_group'], $data);
 		}
 
-		return true;
+		return TRUE;
 	}
 
 	//tested
@@ -1535,9 +1534,9 @@ class Aauth {
 	 */
 	public function send_pm( $sender_id, $receiver_id, $title, $message ){
 
-		if ( !is_numeric($receiver_id) or $sender_id == $receiver_id ){
+		if ( !is_numeric($receiver_id) OR $sender_id == $receiver_id ){
 			$this->error($this->CI->lang->line('aauth_error_self_pm'));
-			return false;
+			return FALSE;
 		}
 
 		$query = $this->CI->db->where('id', $receiver_id);
@@ -1548,7 +1547,7 @@ class Aauth {
 		// if user not exist or banned
 		if ( $query->num_rows() < 1 ){
 			$this->error($this->CI->lang->line('aauth_error_no_user'));
-			return false;
+			return FALSE;
 		}
 
 		$query = $this->CI->db->where('id', $sender_id);
@@ -1559,7 +1558,7 @@ class Aauth {
 		// if user not exist or banned
 		if ( $query->num_rows() < 1 ){
 			$this->error($this->CI->lang->line('aauth_error_no_user'));
-			return false;
+			return FALSE;
 		}
 
 
@@ -1584,15 +1583,15 @@ class Aauth {
 	 * @param int $receiver_id User id of private message receiver
 	 * @return object Array of private messages
 	 */
-	public function list_pms($limit=5, $offset=0, $receiver_id = false, $sender_id=false){
+	public function list_pms($limit=5, $offset=0, $receiver_id = FALSE, $sender_id=FALSE){
 
 		$query='';
 
-		if ( $receiver_id != false){
+		if ( $receiver_id != FALSE){
 			$query = $this->CI->db->where('receiver_id', $receiver_id);
 		}
 
-		if( $sender_id != false ){
+		if( $sender_id != FALSE ){
 			$query = $this->CI->db->where('sender_id', $sender_id);
 		}
 
@@ -1609,7 +1608,7 @@ class Aauth {
 	 * @param bool $set_as_read Whether or not to mark message as read
 	 * @return object Private message
 	 */
-	public function get_pm($pm_id, $set_as_read = true){
+	public function get_pm($pm_id, $set_as_read = TRUE){
 
 		$query = $this->CI->db->where('id', $pm_id);
 		$query = $this->CI->db->get( $this->config_vars['pms'] );
@@ -1639,10 +1638,10 @@ class Aauth {
 	/**
 	 * Count unread Private Message
 	 * Count number of unread private messages
-	 * @param int|bool $receiver_id User id for message receiver, if false returns for current user
+	 * @param int|bool $receiver_id User id for message receiver, if FALSE returns for current user
 	 * @return int Number of unread messages
 	 */
-	public function count_unread_pms($receiver_id=false){
+	public function count_unread_pms($receiver_id=FALSE){
 
 		if(!$receiver_id){
 			$receiver_id = $this->CI->session->userdata('id');
@@ -1678,11 +1677,12 @@ class Aauth {
 	 * Error
 	 * Add message to error array and set flash data
 	 * @param string $message Message to add to array
-	 * @param boolean $flashdata if true add $message to CI flashdata (deflault: false)
+	 * @param boolean $flashdata if TRUE add $message to CI flashdata (deflault: FALSE)
 	 */
-	public function error($message = '', $flashdata = false){
+	public function error($message = '', $flashdata = FALSE){
 		$this->errors[] = $message;
-		if($flashdata) {
+		if($flashdata)
+		{
 			$this->flash_errors[] = $message;
 			$this->CI->session->set_flashdata('errors', $this->flash_errors);
 		}
@@ -1696,14 +1696,15 @@ class Aauth {
 	 * to revive all errors and not let them expire as intended.
 	 * Benefitial when using Ajax Requests
 	 * @see http://ellislab.com/codeigniter/user-guide/libraries/sessions.html
-	 * @param boolean $include_non_flash true if it should stow basic errors as flashdata (default = false)
+	 * @param boolean $include_non_flash TRUE if it should stow basic errors as flashdata (default = FALSE)
 	 */
 	public function keep_errors($include_non_flash = FALSE)
 	{
 		// NOTE: keep_flashdata() overwrites anything new that has been added to flashdata so we are manually reviving flash data
 		// $this->CI->session->keep_flashdata('errors');
 
-		if($include_non_flash) {
+		if($include_non_flash)
+		{
 			$this->flash_errors = array_merge($this->flash_errors, $this->errors);
 		}
 		$this->flash_errors = array_merge($this->flash_errors, (array)$this->CI->session->flashdata('errors'));
@@ -1716,32 +1717,38 @@ class Aauth {
 	 * Return array of errors
 	 * @return array Array of messages, empty array if no errors
 	 */
-	public function get_errors_array(){
+	public function get_errors_array()
+	{
 
-		if (!count($this->errors)==0){
+		if (!count($this->errors)==0)
+		{
 			return $this->errors;
-		} else {
+		}
+		else
+		{
 			return array();
 		}
 	}
 
-	//tested
 	/**
 	 * Print Errors
+	 * 
 	 * Prints string of errors separated by delimiter
 	 * @param string $divider Separator for errors
 	 */
-	public function print_errors($divider = '<br />'){
-
+	public function print_errors($divider = '<br />')
+	{
 		$msg = '';
 		$msg_num = count($this->errors);
 		$i = 1;
-		foreach ($this->errors as $e) {
+		foreach ($this->errors as $e)
+		{
 			$msg .= $e;
 
 			if ($i != $msg_num)
+			{
 				$msg .= $divider;
-
+			}
 			$i++;
 		}
 		echo $msg;
@@ -1752,24 +1759,25 @@ class Aauth {
 	 * 
 	 * Removes errors from error list and clears all associated flashdata
 	 */
-	public function clear_errors() {
+	public function clear_errors()
+	{
 		$this->errors = [];
 		$this->CI->session->set_flashdata('errors', $this->errors);
 	}
 
-	//tested
 	/**
 	 * Info
 	 *
 	 * Add message to info array and set flash data
 	 * 
 	 * @param string $message Message to add to infos array
-	 * @param boolean $flashdata if true add $message to CI flashdata (deflault: false)
+	 * @param boolean $flashdata if TRUE add $message to CI flashdata (deflault: FALSE)
 	 */
-	public function info($message = '', $flashdata = false){
-
+	public function info($message = '', $flashdata = FALSE)
+	{
 		$this->infos[] = $message;
-		if($flashdata) {
+		if($flashdata)
+		{
 			$this->flash_infos[] = $message;
 			$this->CI->session->set_flashdata('infos', $this->flash_infos);
 		}
@@ -1783,14 +1791,15 @@ class Aauth {
 	 * to revive all infos and not let them expire as intended.
 	 * Benefitial by using Ajax Requests
 	 * @see http://ellislab.com/codeigniter/user-guide/libraries/sessions.html
-	 * @param boolean $include_non_flash true if it should stow basic infos as flashdata (default = false)
+	 * @param boolean $include_non_flash TRUE if it should stow basic infos as flashdata (default = FALSE)
 	 */
 	public function keep_infos($include_non_flash = FALSE)
 	{
 		// NOTE: keep_flashdata() overwrites anything new that has been added to flashdata so we are manually reviving flash data
 		// $this->CI->session->keep_flashdata('infos');
 
-		if($include_non_flash) {
+		if($include_non_flash)
+		{
 			$this->flash_infos = array_merge($this->flash_infos, $this->infos);
 		}
 		$this->flash_infos = array_merge($this->flash_infos, (array)$this->CI->session->flashdata('infos'));
@@ -1799,36 +1808,44 @@ class Aauth {
 
 	/**
 	 * Get Info Array
-	 * Return array of info
+	 *
+	 * Return array of infos
 	 * @return array Array of messages, empty array if no errors
 	 */
-	public function get_infos_array(){
-
-		if (!count($this->infos)==0){
+	public function get_infos_array()
+	{
+		if (!count($this->infos)==0)
+		{
 			return $this->infos;
-		} else {
+		}
+		else
+		{
 			return array();
 		}
 	}
 
-	//tested
+
 	/**
 	 * Print Info
+	 *
 	 * Print string of info separated by delimiter
 	 * @param string $divider Separator for info
 	 *
 	 */
-	public function print_infos($divider = '<br />'){
+	public function print_infos($divider = '<br />')
+	{
 
 		$msg = '';
 		$msg_num = count($this->infos);
 		$i = 1;
-		foreach ($this->infos as $e) {
+		foreach ($this->infos as $e)
+		{
 			$msg .= $e;
 
 			if ($i != $msg_num)
+			{
 				$msg .= $divider;
-
+			}
 			$i++;
 		}
 		echo $msg;
@@ -1839,7 +1856,8 @@ class Aauth {
 	 * 
 	 * Removes info messages from info list and clears all associated flashdata
 	 */
-	public function clear_infos() {
+	public function clear_infos()
+	{
 		$this->infos = [];
 		$this->CI->session->set_flashdata('infos', $this->infos);
 	}
@@ -1858,7 +1876,7 @@ class Aauth {
 	 * @param int $user_id ; if not given current user
 	 * @return bool
 	 */
-	public function set_user_var( $key, $value, $user_id = false ) {
+	public function set_user_var( $key, $value, $user_id = FALSE ) {
 
 		if ( ! $user_id ){
 			$user_id = $this->CI->session->userdata('id');
@@ -1866,11 +1884,11 @@ class Aauth {
 
 		// if specified user is not found
 		if ( ! $this->get_user($user_id)){
-			return false;
+			return FALSE;
 		}
 
 		// if var not set, set
-		 if ($this->get_user_var($key,$user_id) ===false) {
+		 if ($this->get_user_var($key,$user_id) ===FALSE) {
 
 			$data = array(
 				'key' => $key,
@@ -1903,7 +1921,7 @@ class Aauth {
 	 * @param int $user_id ; if not given current user
 	 * @return bool
 	 */
-	public function unset_user_var( $key, $user_id = false ) {
+	public function unset_user_var( $key, $user_id = FALSE ) {
 
 		if ( ! $user_id ){
 			$user_id = $this->CI->session->userdata('id');
@@ -1911,7 +1929,7 @@ class Aauth {
 
 		// if specified user is not found
 		if ( ! $this->get_user($user_id)){
-			return false;
+			return FALSE;
 		}
 
 		$this->CI->db->where('key', $key);
@@ -1923,12 +1941,12 @@ class Aauth {
 	//tested
 	/**
 	 * Get User Variable by key
-	 * Return string of variable value or false
+	 * Return string of variable value or FALSE
 	 * @param string $key
 	 * @param int $user_id ; if not given current user
-	 * @return bool|string , false if var is not set, the value of var if set
+	 * @return bool|string , FALSE if var is not set, the value of var if set
 	 */
-	public function get_user_var( $key, $user_id = false){
+	public function get_user_var( $key, $user_id = FALSE){
 
 		if ( ! $user_id ){
 			$user_id = $this->CI->session->userdata('id');
@@ -1936,7 +1954,7 @@ class Aauth {
 
 		// if specified user is not found
 		if ( ! $this->get_user($user_id)){
-			return false;
+			return FALSE;
 		}
 
 		$query = $this->CI->db->where('user_id', $user_id);
@@ -1945,7 +1963,7 @@ class Aauth {
 		$query = $this->CI->db->get( $this->config_vars['user_variables'] );
 
 		// if variable not set
-		if ($query->num_rows() < 1) { return false;}
+		if ($query->num_rows() < 1) { return FALSE;}
 
 		else {
 
@@ -1958,11 +1976,11 @@ class Aauth {
    
 	/**
 	 * List User Variable Keys by UserID
-	 * Return array of variable keys or false
+	 * Return array of variable keys or FALSE
 	 * @param int $user_id ; if not given current user
-	 * @return bool|array, false if no user vars, otherwise array
+	 * @return bool|array, FALSE if no user vars, otherwise array
 	 */
-	public function list_user_var_keys($user_id = false){
+	public function list_user_var_keys($user_id = FALSE){
 
 		if ( ! $user_id ){
 			$user_id = $this->CI->session->userdata('id');
@@ -1970,7 +1988,7 @@ class Aauth {
 
 		// if specified user is not found
 		if ( ! $this->get_user($user_id)){
-			return false;
+			return FALSE;
 		}
 		$query = $this->CI->db->select('key');
 
@@ -1979,7 +1997,7 @@ class Aauth {
 		$query = $this->CI->db->get( $this->config_vars['user_variables'] );
 
 		// if variable not set
-		if ($query->num_rows() < 1) { return false;}
+		if ($query->num_rows() < 1) { return FALSE;}
 		else {
 			$key_list = array();
 			foreach( $query->result() as $row) {
@@ -2045,9 +2063,9 @@ class Aauth {
 	//tested
 	/**
 	 * Get Aauth System Variable by key
-	 * Return string of variable value or false
+	 * Return string of variable value or FALSE
 	 * @param string $key
-	 * @return bool|string , false if var is not set, the value of var if set
+	 * @return bool|string , FALSE if var is not set, the value of var if set
 	 */
 	public function get_system_var( $key ){
 
@@ -2056,7 +2074,7 @@ class Aauth {
 		$query = $this->CI->db->get( $this->config_vars['system_variables'] );
 
 		// if variable not set
-		if ($query->num_rows() < 1) { return false;}
+		if ($query->num_rows() < 1) { return FALSE;}
 
 		else {
 
@@ -2067,15 +2085,15 @@ class Aauth {
 	
 	 /**
 	 * List System Variable Keys
-	 * Return array of variable keys or false
-	 * @return bool|array , false if var is not set, the value of var if set
+	 * Return array of variable keys or FALSE
+	 * @return bool|array , FALSE if var is not set, the value of var if set
 	 */
 
 	public function list_system_var_keys(){
 		$query = $this->CI->db->select('key');
 		$query = $this->CI->db->get( $this->config_vars['system_variables'] );
 		// if variable not set
-		if ($query->num_rows() < 1) { return false;}
+		if ($query->num_rows() < 1) { return FALSE;}
 		else {
 			return $query->result();
 		}
@@ -2083,7 +2101,7 @@ class Aauth {
 
 	public function generate_recaptcha_field(){
 		$content = '';
-		if($this->config_vars['ddos_protection'] and $this->config_vars['recaptcha_active'] and $this->CI->input->cookie('reCAPTCHA', TRUE) == 'true'){
+		if($this->config_vars['ddos_protection'] && $this->config_vars['recaptcha_active'] && $this->CI->input->cookie('reCAPTCHA', TRUE) == 'true'){
 			$content .= "<script type='text/javascript' src='https://www.google.com/recaptcha/api.js'></script>";
 			$siteKey = $this->config_vars['recaptcha_siteKey'];
 			$content .= "<div class='g-recaptcha' data-sitekey='{$siteKey}'></div>";
@@ -2144,11 +2162,11 @@ class Aauth {
  * get_errors() changed to print_errors()
  * get_infos() changed to print_infos()
  * User and Aauth System Variables.
-set_user_var( $key, $value, $user_id = false )
-get_user_var( $key, $user_id = false)
+set_user_var( $key, $value, $user_id = FALSE )
+get_user_var( $key, $user_id = FALSE)
 unset
-set_system_var( $key, $value, $user_id = false )
-get_system_var( $key, $user_id = false)
+set_system_var( $key, $value, $user_id = FALSE )
+get_system_var( $key, $user_id = FALSE)
 unset
 functions added
  *
@@ -2189,7 +2207,7 @@ $row = $query->row();
 if ( $this->config_vars['dos_protection'] and $row->last_login_attempt != '' and
 (strtotime("now") + 30 * $this->config_vars['try'] ) < strtotime($row->last_login_attempt) ) {
 $this->error($this->CI->lang->line('exceeded'));
-return false;
+return FALSE;
 }
 }
  */

--- a/application/libraries/Aauth.php
+++ b/application/libraries/Aauth.php
@@ -20,6 +20,8 @@
  * The latest version of Aauth can be obtained from:
  * https://github.com/emreakay/CodeIgniter-Aauth
  *
+ * @todo separate (on some level) the unvalidated users from the "banned" users
+ * @todo remove requirement for unique name/username (or default it to use email address, perhaps via config file)
  */
 class Aauth {
 
@@ -1790,7 +1792,7 @@ class Aauth {
      * 
      * Removes info messages from info list and clears all associated flashdata
      */
-    public function clear_errors() {
+    public function clear_info() {
     	$this->infos = [];
     	$this->CI->session->set_flashdata('infos', $this->infos);
     }
@@ -2144,5 +2146,5 @@ return false;
 
 
 
-
-
+/* End of file Aauth.php */
+/* Location: ./application/libraries/Aauth.php */

--- a/application/libraries/Aauth.php
+++ b/application/libraries/Aauth.php
@@ -1659,8 +1659,6 @@ class Aauth {
 		}
     }
 
-    //not working
-    // NOTE: this should now be working.
     /**
      * Keep Errors
      * keeps the flash data flash data
@@ -1736,8 +1734,6 @@ class Aauth {
 		}
     }
 
-    //not working
-    // NOTE: This should now be working
     /**
      * Keep Infos
      * keeps the flash data
@@ -1792,7 +1788,7 @@ class Aauth {
      * 
      * Removes info messages from info list and clears all associated flashdata
      */
-    public function clear_info() {
+    public function clear_infos() {
     	$this->infos = [];
     	$this->CI->session->set_flashdata('infos', $this->infos);
     }

--- a/sql/Aauth_v2.sql
+++ b/sql/Aauth_v2.sql
@@ -22,8 +22,7 @@ DROP TABLE IF EXISTS `aauth_groups`;
 CREATE TABLE `aauth_groups` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` text,
-  PRIMARY KEY (`id`),
-  KEY `id_index` (`id`)
+  PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8;
 
 -- ----------------------------
@@ -41,8 +40,7 @@ CREATE TABLE `aauth_perms` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` text,
   `definition` text,
-  PRIMARY KEY (`id`),
-  KEY `id_index` (`id`)
+  PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- ----------------------------
@@ -135,8 +133,7 @@ CREATE TABLE `aauth_users` (
   `verification_code` text COLLATE utf8_general_ci,
   `ip_address` text COLLATE utf8_general_ci,
   `login_attempts` int(11) DEFAULT '0',
-  PRIMARY KEY (`id`),
-  KEY `id_index` (`id`)
+  PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 
 -- ----------------------------

--- a/sql/Aauth_v2.sql
+++ b/sql/Aauth_v2.sql
@@ -1,16 +1,5 @@
 /*
-Navicat MySQL Data Transfer
-
-Source Server         : local
-Source Server Version : 50508
-Source Host           : localhost:3306
-Source Database       : aauth_v2_dev
-
-Target Server Type    : MYSQL
-Target Server Version : 50508
-File Encoding         : 65001
-
-Date: 2014-07-03 21:23:21
+	Aauth SQL Table Structure
 */
 
 SET FOREIGN_KEY_CHECKS=0;
@@ -20,25 +9,26 @@ SET FOREIGN_KEY_CHECKS=0;
 -- ----------------------------
 DROP TABLE IF EXISTS `aauth_groups`;
 CREATE TABLE `aauth_groups` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` text,
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(100),
+  `definition` text,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8;
 
 -- ----------------------------
 -- Records of aauth_groups
 -- ----------------------------
-INSERT INTO `aauth_groups` VALUES ('1', 'Admin');
-INSERT INTO `aauth_groups` VALUES ('2', 'Public');
-INSERT INTO `aauth_groups` VALUES ('3', 'Default');
+INSERT INTO `aauth_groups` VALUES ('1', 'Admin', 'Super Admin Group');
+INSERT INTO `aauth_groups` VALUES ('2', 'Public', 'Public Access Group');
+INSERT INTO `aauth_groups` VALUES ('3', 'Default', 'Default Access Group');
 
 -- ----------------------------
 -- Table structure for `aauth_perms`
 -- ----------------------------
 DROP TABLE IF EXISTS `aauth_perms`;
 CREATE TABLE `aauth_perms` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` text,
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(100),
   `definition` text,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -52,11 +42,9 @@ CREATE TABLE `aauth_perms` (
 -- ----------------------------
 DROP TABLE IF EXISTS `aauth_perm_to_group`;
 CREATE TABLE `aauth_perm_to_group` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `perm_id` int(11) DEFAULT NULL,
-  `group_id` int(11) DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  KEY `perm_id_group_id_index` (`perm_id`,`group_id`)
+  `perm_id` int(11) unsigned DEFAULT NULL,
+  `group_id` int(11) unsigned DEFAULT NULL,
+  PRIMARY KEY (`perm_id`,`group_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- ----------------------------
@@ -68,11 +56,9 @@ CREATE TABLE `aauth_perm_to_group` (
 -- ----------------------------
 DROP TABLE IF EXISTS `aauth_perm_to_user`;
 CREATE TABLE `aauth_perm_to_user` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `perm_id` int(11) DEFAULT NULL,
-  `user_id` int(11) DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  KEY `perm_id_user_id_index` (`perm_id`,`user_id`)
+  `perm_id` int(11) unsigned DEFAULT NULL,
+  `user_id` int(11) unsigned DEFAULT NULL,
+  PRIMARY KEY (`perm_id`,`user_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- ----------------------------
@@ -84,13 +70,13 @@ CREATE TABLE `aauth_perm_to_user` (
 -- ----------------------------
 DROP TABLE IF EXISTS `aauth_pms`;
 CREATE TABLE `aauth_pms` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `sender_id` int(11) NOT NULL,
-  `receiver_id` int(11) NOT NULL,
-  `title` text NOT NULL,
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `sender_id` int(11) unsigned NOT NULL,
+  `receiver_id` int(11) unsigned NOT NULL,
+  `title` varchar(255) NOT NULL,
   `message` text,
   `date` datetime DEFAULT NULL,
-  `read` int(11) DEFAULT '0',
+  `read` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `full_index` (`id`,`sender_id`,`receiver_id`,`read`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -104,8 +90,8 @@ CREATE TABLE `aauth_pms` (
 -- ----------------------------
 DROP TABLE IF EXISTS `aauth_system_variables`;
 CREATE TABLE `aauth_system_variables` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `key` text NOT NULL,
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `key` varchar(100) NOT NULL,
   `value` text,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -119,11 +105,11 @@ CREATE TABLE `aauth_system_variables` (
 -- ----------------------------
 DROP TABLE IF EXISTS `aauth_users`;
 CREATE TABLE `aauth_users` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `email` text COLLATE utf8_general_ci NOT NULL,
-  `pass` text COLLATE utf8_general_ci NOT NULL,
-  `name` text COLLATE utf8_general_ci,
-  `banned` int(11) DEFAULT '0',
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `email` varchar(100) COLLATE utf8_general_ci NOT NULL,
+  `pass` varchar(50) COLLATE utf8_general_ci NOT NULL,
+  `name` varchar(100) COLLATE utf8_general_ci,
+  `banned` tinyint(1) DEFAULT '0',
   `last_login` datetime DEFAULT NULL,
   `last_activity` datetime DEFAULT NULL,
   `last_login_attempt` datetime DEFAULT NULL,
@@ -139,17 +125,16 @@ CREATE TABLE `aauth_users` (
 -- ----------------------------
 -- Records of aauth_users
 -- ----------------------------
-INSERT INTO `aauth_users` VALUES ('1', 'admin@admin.com', 'dd5073c93fb477a167fd69072e95455834acd93df8fed41a2c468c45b394bfe3', 'Admin', '0', null, null, null, null, null, null, null, null, '0');
+INSERT INTO `aauth_users` VALUES ('1', 'admin@example.com', 'dd5073c93fb477a167fd69072e95455834acd93df8fed41a2c468c45b394bfe3', 'Admin', '0', null, null, null, null, null, null, null, null, '0');
 
 -- ----------------------------
 -- Table structure for `aauth_user_to_group`
 -- ----------------------------
 DROP TABLE IF EXISTS `aauth_user_to_group`;
 CREATE TABLE `aauth_user_to_group` (
-  `user_id` int(11) NOT NULL DEFAULT '0',
-  `group_id` int(11) NOT NULL DEFAULT '0',
-  PRIMARY KEY (`user_id`,`group_id`),
-  KEY `user_id_group_id_index` (`user_id`,`group_id`)
+  `user_id` int(11) unsigned NOT NULL DEFAULT '0',
+  `group_id` int(11) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`user_id`,`group_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- ----------------------------
@@ -163,9 +148,9 @@ INSERT INTO `aauth_user_to_group` VALUES ('1', '3');
 -- ----------------------------
 DROP TABLE IF EXISTS `aauth_user_variables`;
 CREATE TABLE `aauth_user_variables` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `user_id` int(11) NOT NULL,
-  `key` text NOT NULL,
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) unsigned NOT NULL,
+  `key` varchar(100) NOT NULL,
   `value` text,
   PRIMARY KEY (`id`),
   KEY `user_id_index` (`user_id`)

--- a/sql/readme.txt
+++ b/sql/readme.txt
@@ -1,8 +1,8 @@
 Aauth V2 Database
 -----------------
 
-- First you must create a database.
-- Execute sql "Aauth.sql" file in your database
-- Don't forget to change database connection setups from application/config/database.php
+- First open your database (or create one if you have not already done so)
+- Execute sql "Aauth_v2.sql" file in your database
+- If you have not already, don't forget to change database connection settings in application/config/database.php
 
 That's All :) 


### PR DESCRIPTION
I have addressed a few issues/bugs with the core functionality (mostly surrounding the info and errors) as well as added a few minor features.  Below is a list of changes:

- Added flashdata boolean to error() and info() allowing the option for errors/messages to only remain for current page.
- Added clear_errors() and clear_infos() which removes all errors and infos from Aauth storage as well as flashdata storage
- Loaded flashdata into errors and infos on construct in order to fully utilize flashdata (as a result, keep_errors() and keep_infos() now work properly)
- Added boolean return value to login_fast()
- Remove redundant indexes from Aauth_v2.sql
- Removed bool return value from get_errors_array() and get_infos_array().  As "array" is in the method name, should only return array.  Change should remain backwards compatible as empty array will still evaluate to "false".
- Fix bug in which "is_allowed" returns true if user is logged in and has access to perm_id=1 and perm is non-existant.
- Modified list_user_var_keys() to return an array so that it can be looped through
- Fixed duplicate message when sending password reset email, line 424
- Modified lang-file constants to include prefix.  This will help avoid collisions. Also added a few missing items to the lang-file
- Updated SQL file to be a bit more efficient.
- Modified keep_infos() and keep_errors() to include non-flash data values on optional boolean parameter.