### PR TITLE
Password errors were not being thrown

### DIFF
--- a/application/language/english/aauth_lang.php
+++ b/application/language/english/aauth_lang.php
@@ -38,6 +38,7 @@ $lang['aauth_error_update_username_exists'] = "Username already exists on the sy
 $lang['aauth_error_no_access'] = 'Sorry, you do not have access to the resource you requested.';
 $lang['aauth_error_login_failed_email'] = 'E-mail Address and Password do not match.';
 $lang['aauth_error_login_failed_name'] = 'Username and Password do not match.';
+$lang['aauth_error_login_failed_all'] = 'E-mail, Username or Password do not match.';
 $lang['aauth_error_login_attempts_exceeded'] = 'You have exceeded your login attempts, your account has now been locked.';
 $lang['aauth_error_recaptcha_not_correct'] = 'Sorry, the reCAPTCHA text entered was incorrect.';
 

--- a/application/libraries/Aauth.php
+++ b/application/libraries/Aauth.php
@@ -349,7 +349,7 @@ class Aauth {
 		// if not matches
 		else {
 
-			$this->error($this->CI->lang->line('aauth_error_login_failed'));
+			$this->error($this->CI->lang->line('aauth_error_login_failed_all'));
 			return FALSE;
 		}
 	}


### PR DESCRIPTION
I noticed that password errors were not being thrown if the password was not the correct. This is because  on line 353, the error being thrown is <pre>$this->error($this->CI->lang->line('aauth_error_login_failed'));</pre> but in the <pre>application/language/english/aauth_lang.php</pre> the line is missing. My personal fix was to add a line in the <pre>aauth_lang.php</pre> file in accordance to what was already there. 

To Mr. Emre: I don't want to re-invent the wheel here. You can reject this if it doesn't sound sensible. I'm just trying to help

p.s. I'm always using CI3.