### PR TITLE
Update array clearing for php compatibilities

### DIFF
--- a/application/libraries/Aauth.php
+++ b/application/libraries/Aauth.php
@@ -1908,7 +1908,7 @@ class Aauth {
 	 */
 	public function clear_errors()
 	{
-		$this->errors = [];
+		$this->errors = array();
 		$this->CI->session->set_flashdata('errors', $this->errors);
 	}
 
@@ -1998,7 +1998,7 @@ class Aauth {
 	 */
 	public function clear_infos()
 	{
-		$this->infos = [];
+		$this->infos = array();
 		$this->CI->session->set_flashdata('infos', $this->infos);
 	}
 


### PR DESCRIPTION
remove array clearing method (lines 1911 and 2001) :
```php
$this->infos = [];
```
in profit of a more php compatible method (php 5.3.28 tested) :
```php
$this->infos = array();
```