### PR TITLE
Sub-Groups added (group hierarchy #115) & some enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ $this->aauth->allow_group('elves','immortality');
 $this->aauth->allow_group('hobbits','immortality');
 ``` 
 
-Wait a minute! Hobbits should not have `immortality`. We need to fix this, we can use `deny()` to remove the permission.
+Wait a minute! Hobbits should not have `immortality`. We need to fix this, we can use `deny_group()` to remove the permission.
 
 ```php
-$this->aauth->deny('hobbits','immortality');
+$this->aauth->deny_group('hobbits','immortality');
 ``` 
 
 Gandalf can also live forever.

--- a/application/config/aauth.php
+++ b/application/config/aauth.php
@@ -38,7 +38,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 | 	['max']                            	Maximum char long for Password
 | 	['min']                            	Minimum char long for Password
 |
-| 	['valid_chars']                    	Valid chars for username. Non alphanumeric characters that are allowed by default
+| 	['additional_valid_chars']          Additional valid chars for username. Non alphanumeric characters that are allowed by default
 |
 | 	['ddos_protection']                	If it is true, the user will be banned temporary when he exceed the login 'try'
 |
@@ -95,7 +95,7 @@ $config_aauth["default"] = array(
 	'max'                            => 13,
 	'min'                            => 5,
 
-	'valid_chars'                    => array(),
+	'additional_valid_chars'         => array(),
 
 	'ddos_protection'                => true,
 

--- a/application/config/aauth.php
+++ b/application/config/aauth.php
@@ -81,6 +81,7 @@ $config_aauth["default"] = array(
 
 	'users'                          => 'aauth_users',
 	'groups'                         => 'aauth_groups',
+	'group_to_group'                 => 'aauth_group_to_group',
 	'user_to_group'                  => 'aauth_user_to_group',
 	'perms'                          => 'aauth_perms',
 	'perm_to_group'                  => 'aauth_perm_to_group',

--- a/application/language/english/aauth_lang.php
+++ b/application/language/english/aauth_lang.php
@@ -46,11 +46,13 @@ $lang['aauth_error_recaptcha_not_correct'] = 'Sorry, the reCAPTCHA text entered 
 $lang['aauth_error_no_user'] = 'User does not exist';
 $lang['aauth_error_account_not_verified'] = 'Your account has not been verified. Please check your e-mail and verify your account.';
 $lang['aauth_error_no_group'] = 'Group does not exist';
+$lang['aauth_error_no_subgroup'] = 'Subgroup does not exist';
 $lang['aauth_error_self_pm'] = 'It is not possible to send a Message to yourself.';
 $lang['aauth_error_no_pm'] = 'Private Message not found';
 
 
 /* Info messages */
 $lang['aauth_info_already_member'] = 'User is already member of group';
+$lang['aauth_info_already_subgroup'] = 'Subgroup is already member of group';
 $lang['aauth_info_group_exists'] = 'Group name already exists';
 $lang['aauth_info_perm_exists'] = 'Permission name already exists';

--- a/application/libraries/Aauth.php
+++ b/application/libraries/Aauth.php
@@ -745,7 +745,7 @@ class Aauth {
 			$this->add_member($user_id, $this->config_vars['default_group']);
 
 			// if verification activated
-			if($this->config_vars['verification']){
+			if($this->config_vars['verification'] && !$this->is_admin()){
 				$data = null;
 				$data['banned'] = 1;
 

--- a/application/libraries/Aauth.php
+++ b/application/libraries/Aauth.php
@@ -2236,6 +2236,33 @@ class Aauth {
 	}
 	
    
+    /**
+	 * Get User Variables by user id
+	 * Return array with all user keys & variables
+	 * @param int $user_id ; if not given current user
+	 * @return bool|array , FALSE if var is not set, the value of var if set
+	 */
+	public function get_user_vars( $user_id = FALSE){
+
+		if ( ! $user_id ){
+			$user_id = $this->CI->session->userdata('id');
+		}
+
+		// if specified user is not found
+		if ( ! $this->get_user($user_id)){
+			return FALSE;
+		}
+
+		$query = $this->aauth_db->select('data_key, value');
+
+		$query = $this->aauth_db->where('user_id', $user_id);
+
+		$query = $this->aauth_db->get( $this->config_vars['user_variables'] );
+
+		return $query->result();
+
+	}
+
 	/**
 	 * List User Variable Keys by UserID
 	 * Return array of variable keys or FALSE

--- a/application/libraries/Aauth.php
+++ b/application/libraries/Aauth.php
@@ -723,7 +723,7 @@ class Aauth {
 			$this->error($this->CI->lang->line('aauth_error_password_invalid'));
 			$valid = FALSE;
 		}
-		if ($name != FALSE && !ctype_alnum(str_replace($this->config_vars['valid_chars'], '', $name))){
+		if ($name != FALSE && !ctype_alnum(str_replace($this->config_vars['additional_valid_chars'], '', $name))){
 			$this->error($this->CI->lang->line('aauth_error_username_invalid'));
 			$valid = FALSE;
 		}
@@ -819,7 +819,7 @@ class Aauth {
 				$this->error($this->CI->lang->line('aauth_error_update_username_exists'));
 				$valid = FALSE;
 			}
-			if ($name !='' && !ctype_alnum(str_replace($this->config_vars['valid_chars'], '', $name))){
+			if ($name !='' && !ctype_alnum(str_replace($this->config_vars['additional_valid_chars'], '', $name))){
 				$this->error($this->CI->lang->line('aauth_error_username_invalid'));
 				$valid = FALSE;
 			}

--- a/sql/Aauth_v2.sql
+++ b/sql/Aauth_v2.sql
@@ -160,3 +160,18 @@ CREATE TABLE `aauth_user_variables` (
 -- ----------------------------
 -- Records of aauth_user_variables
 -- ----------------------------
+
+-- ----------------------------
+-- Table structure for `aauth_perm_to_group`
+-- ----------------------------
+DROP TABLE IF EXISTS `aauth_group_to_group`;
+CREATE TABLE `aauth_group_to_group` (
+  `group_id` int(11) unsigned DEFAULT NULL,
+  `subgroup_id` int(11) unsigned DEFAULT NULL,
+  PRIMARY KEY (`group_id`,`subgroup_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- ----------------------------
+-- Records of aauth_perm_to_group
+-- ----------------------------
+


### PR DESCRIPTION
- added function `add_subgroup($group_par, $subgroup_par)`
- added function `remove_subgroup($group_par, $subgroup_par)`
- added function `get_subgroups($group_par)`
- modified `is_group_allowed()` to check subgroups
- modified `delete_group()` to remove subgroups
- added 2 lines for subgroups to `english/aauth_lang.php`
- added a new table to the database `group_to_group`
- changed verstion from 2.4.6 to 2.4.7
- verification email sending disabled if a admin is creating a user (#119 improved with @vipinks)
- fixed `Quick Start`-Section (changed `deny` to `deny_group`) (found by #118)
- renamed `valid_chars` to `additional_valid_chars` (suggestion by #125)
- added function `get_user_vars($user_id)` (suggestion by #129)
@emreakay if its ok pls create a new release