### PR TITLE
enable/disable verification email

### DIFF
--- a/application/libraries/Aauth.php
+++ b/application/libraries/Aauth.php
@@ -693,6 +693,7 @@ class Aauth {
 	 * @param string $email User's email address
 	 * @param string $pass User's password
 	 * @param string $name User's name
+	 * @param bool $send_verification Send verification email to user
 	 * @return int|bool False if create fails or returns user id if successful
 	 */
 	public function create_user($email, $pass, $name='', $send_verification = TRUE) {

--- a/application/libraries/Aauth.php
+++ b/application/libraries/Aauth.php
@@ -695,7 +695,7 @@ class Aauth {
 	 * @param string $name User's name
 	 * @return int|bool False if create fails or returns user id if successful
 	 */
-	public function create_user($email, $pass, $name='') {
+	public function create_user($email, $pass, $name='', $send_verification = TRUE) {
 
 		$valid = TRUE;
 
@@ -744,15 +744,17 @@ class Aauth {
 			$this->add_member($user_id, $this->config_vars['default_group']);
 
 			// if verification activated
-			if($this->config_vars['verification']){
-				$data = null;
-				$data['banned'] = 1;
-
-				$this->aauth_db->where('id', $user_id);
-				$this->aauth_db->update($this->config_vars['users'], $data);
-
-				// sends verifition ( !! e-mail settings must be set)
-				$this->send_verification($user_id);
+			if($send_verification) {
+				if($this->config_vars['verification']){
+					$data = null;
+					$data['banned'] = 1;
+	
+					$this->aauth_db->where('id', $user_id);
+					$this->aauth_db->update($this->config_vars['users'], $data);
+	
+					// sends verifition ( !! e-mail settings must be set)
+					$this->send_verification($user_id);
+				}
 			}
 
 			// Update to correct salted password


### PR DESCRIPTION
verification email sending can be disabled while creating user manually from site's admin area, as of now it only checks verification from config file. It is ok for website's frontend user registration, but what if an admin wants to  stop verification email while creating users manually? Developers don't have choice to give a functionality to non programmer admins or admins who don't have access to aauth.php config file. 